### PR TITLE
Fix CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# The CI jobs only read the repository contents; grant the minimum
+# token scope so a compromised action cannot push to the repo.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/internal/functions/array/array_offset.go
+++ b/internal/functions/array/array_offset.go
@@ -23,5 +23,9 @@ var BindArrayAtOffset = helper.Scalar2(func(a, b value.Value) (value.Value, erro
 	if err != nil {
 		return nil, err
 	}
-	return ARRAY_OFFSET(a, int(i64))
+	idx, err := helper.SafeInt(i64)
+	if err != nil {
+		return nil, err
+	}
+	return ARRAY_OFFSET(a, idx)
 })

--- a/internal/functions/array/array_ordinal.go
+++ b/internal/functions/array/array_ordinal.go
@@ -23,5 +23,9 @@ var BindArrayAtOrdinal = helper.Scalar2(func(a, b value.Value) (value.Value, err
 	if err != nil {
 		return nil, err
 	}
-	return ARRAY_ORDINAL(a, int(i64))
+	idx, err := helper.SafeInt(i64)
+	if err != nil {
+		return nil, err
+	}
+	return ARRAY_ORDINAL(a, idx)
 })

--- a/internal/functions/array/array_safe_offset.go
+++ b/internal/functions/array/array_safe_offset.go
@@ -21,5 +21,9 @@ var BindSafeArrayAtOffset = helper.Scalar2(func(a, b value.Value) (value.Value, 
 	if err != nil {
 		return nil, err
 	}
-	return ARRAY_SAFE_OFFSET(a, int(i64))
+	idx, err := helper.SafeInt(i64)
+	if err != nil {
+		return nil, err
+	}
+	return ARRAY_SAFE_OFFSET(a, idx)
 })

--- a/internal/functions/array/array_safe_ordinal.go
+++ b/internal/functions/array/array_safe_ordinal.go
@@ -21,5 +21,9 @@ var BindSafeArrayAtOrdinal = helper.Scalar2(func(a, b value.Value) (value.Value,
 	if err != nil {
 		return nil, err
 	}
-	return ARRAY_SAFE_ORDINAL(a, int(i64))
+	idx, err := helper.SafeInt(i64)
+	if err != nil {
+		return nil, err
+	}
+	return ARRAY_SAFE_ORDINAL(a, idx)
 })

--- a/internal/functions/bit/bit_cast_to_int32.go
+++ b/internal/functions/bit/bit_cast_to_int32.go
@@ -3,6 +3,7 @@ package bit
 import (
 	"fmt"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -17,5 +18,13 @@ func BIT_CAST_TO_INT32(v value.Value) (value.Value, error) {
 	if x < -1<<31 || x > 1<<32-1 {
 		return nil, fmt.Errorf("BIT_CAST_TO_INT32: %d out of [INT32_MIN, UINT32_MAX]", x)
 	}
-	return value.IntValue(int64(int32(uint32(x)))), nil
+	// Reinterpret the low 32 bits of x as a signed int32. x may be
+	// negative, so mask first to obtain a value in [0, 4294967295]
+	// before the checked uint32 conversion.
+	masked := x & 0xFFFFFFFF
+	u, err := helper.SafeUint32(masked)
+	if err != nil {
+		return nil, err
+	}
+	return value.IntValue(int64(int32(u))), nil
 }

--- a/internal/functions/date/date.go
+++ b/internal/functions/date/date.go
@@ -21,7 +21,19 @@ func DATE(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		return value.DateValue(time.Time{}.AddDate(int(year)-1, int(month)-1, int(day)-1)), nil
+		yearInt, err := helper.SafeInt(year)
+		if err != nil {
+			return nil, err
+		}
+		monthInt, err := helper.SafeInt(month)
+		if err != nil {
+			return nil, err
+		}
+		dayInt, err := helper.SafeInt(day)
+		if err != nil {
+			return nil, err
+		}
+		return value.DateValue(time.Time{}.AddDate(yearInt-1, monthInt-1, dayInt-1)), nil
 	} else if len(args) == 2 {
 		t, err := args[0].ToTime()
 		if err != nil {

--- a/internal/functions/date/date_add.go
+++ b/internal/functions/date/date_add.go
@@ -11,13 +11,29 @@ import (
 func DATE_ADD(t time.Time, v int64, part string) (value.Value, error) {
 	switch part {
 	case "DAY":
-		return value.DateValue(t.AddDate(0, 0, int(v))), nil
+		n, err := helper.SafeInt(v)
+		if err != nil {
+			return nil, err
+		}
+		return value.DateValue(t.AddDate(0, 0, n)), nil
 	case "WEEK":
-		return value.DateValue(t.AddDate(0, 0, int(v*7))), nil
+		n, err := helper.SafeInt(v * 7)
+		if err != nil {
+			return nil, err
+		}
+		return value.DateValue(t.AddDate(0, 0, n)), nil
 	case "MONTH":
-		return value.DateValue(helper.AddMonth(t, int(v))), nil
+		n, err := helper.SafeInt(v)
+		if err != nil {
+			return nil, err
+		}
+		return value.DateValue(helper.AddMonth(t, n)), nil
 	case "YEAR":
-		return value.DateValue(helper.AddYear(t, int(v))), nil
+		n, err := helper.SafeInt(v)
+		if err != nil {
+			return nil, err
+		}
+		return value.DateValue(helper.AddYear(t, n)), nil
 	case "QUARTER":
 		return value.DateValue(helper.AddMonth(t, 3)), nil
 	}

--- a/internal/functions/date/generate_date_array.go
+++ b/internal/functions/date/generate_date_array.go
@@ -3,6 +3,7 @@ package date
 import (
 	"fmt"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -32,7 +33,11 @@ func GENERATE_DATE_ARRAY(start, end value.Value, step ...value.Value) (value.Val
 		}
 		stepValue = stepV
 	}
-	return generateDateArray(start, end, int(stepValue), interval)
+	step32, err := helper.SafeInt(stepValue)
+	if err != nil {
+		return nil, err
+	}
+	return generateDateArray(start, end, step32, interval)
 }
 
 func BindGenerateDateArray(args ...value.Value) (value.Value, error) {

--- a/internal/functions/datetime/datetime.go
+++ b/internal/functions/datetime/datetime.go
@@ -38,13 +38,37 @@ func DATETIME(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
+		yearInt, err := helper.SafeInt(year)
+		if err != nil {
+			return nil, err
+		}
+		monthInt, err := helper.SafeInt(month)
+		if err != nil {
+			return nil, err
+		}
+		dayInt, err := helper.SafeInt(day)
+		if err != nil {
+			return nil, err
+		}
+		hourInt, err := helper.SafeInt(hour)
+		if err != nil {
+			return nil, err
+		}
+		minuteInt, err := helper.SafeInt(minute)
+		if err != nil {
+			return nil, err
+		}
+		secondInt, err := helper.SafeInt(second)
+		if err != nil {
+			return nil, err
+		}
 		return value.DatetimeValue(time.Date(
-			int(year),
-			time.Month(month),
-			int(day),
-			int(hour),
-			int(minute),
-			int(second),
+			yearInt,
+			time.Month(monthInt),
+			dayInt,
+			hourInt,
+			minuteInt,
+			secondInt,
 			0,
 			location,
 		)), nil

--- a/internal/functions/geography/accessors.go
+++ b/internal/functions/geography/accessors.go
@@ -1,6 +1,7 @@
 package geography
 
 import (
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -56,7 +57,10 @@ func BindStPointN(args ...value.Value) (value.Value, error) {
 	if !ok || len(pts) == 0 {
 		return nil, nil
 	}
-	idx := int(n)
+	idx, err := helper.SafeInt(n)
+	if err != nil {
+		return nil, err
+	}
 	if idx > 0 {
 		idx--
 	} else if idx < 0 {
@@ -85,7 +89,11 @@ func BindStGeometryN(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	idx := int(n) - 1
+	nInt, err := helper.SafeInt(n)
+	if err != nil {
+		return nil, err
+	}
+	idx := nInt - 1
 	if idx < 0 {
 		return nil, nil
 	}

--- a/internal/functions/geography/extras.go
+++ b/internal/functions/geography/extras.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -641,7 +642,10 @@ func BindS2CellIDFromPoint(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		level = int(l)
+		level, err = helper.SafeInt(l)
+		if err != nil {
+			return nil, err
+		}
 		if level < 0 || level > 30 {
 			return nil, sqError("S2_CELLIDFROMPOINT", "level out of range [0, 30]")
 		}
@@ -680,14 +684,20 @@ func BindS2CoveringCellIDs(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		minLevel = int(l)
+		minLevel, err = helper.SafeInt(l)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if len(args) >= 3 && args[2] != nil {
 		l, err := args[2].ToInt64()
 		if err != nil {
 			return nil, err
 		}
-		maxLevel = int(l)
+		maxLevel, err = helper.SafeInt(l)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if len(args) >= 4 && args[3] != nil {
 		n, err := args[3].ToInt64()
@@ -695,7 +705,10 @@ func BindS2CoveringCellIDs(args ...value.Value) (value.Value, error) {
 			return nil, err
 		}
 		if n > 0 {
-			maxCells = int(n)
+			maxCells, err = helper.SafeInt(n)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	cov := &s2.RegionCoverer{MinLevel: minLevel, MaxLevel: maxLevel, MaxCells: maxCells}
@@ -928,7 +941,10 @@ func BindStGeoHash(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		precision = int(p)
+		precision, err = helper.SafeInt(p)
+		if err != nil {
+			return nil, err
+		}
 		if precision < 1 || precision > 20 {
 			return nil, sqError("ST_GEOHASH", "precision out of range [1, 20]")
 		}

--- a/internal/functions/geography/setops.go
+++ b/internal/functions/geography/setops.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/geo/s2"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -139,7 +140,10 @@ func BindStBuffer(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		segPerQuarter = int(s)
+		segPerQuarter, err = helper.SafeInt(s)
+		if err != nil {
+			return nil, err
+		}
 		if segPerQuarter < 1 {
 			segPerQuarter = 1
 		}

--- a/internal/functions/geography/st_clusterdbscan_window.go
+++ b/internal/functions/geography/st_clusterdbscan_window.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/functions/window"
 	"github.com/goccy/googlesqlite/internal/value"
 )
@@ -45,7 +46,11 @@ func (f *WINDOW_ST_CLUSTERDBSCAN) Step(geo, epsv, minPtsv value.Value, opt *wind
 			if n < 0 {
 				return fmt.Errorf("ST_CLUSTERDBSCAN: minimum_geographies must be non-negative, got %d", n)
 			}
-			f.minPts = int(n)
+			minPts, err := helper.SafeInt(n)
+			if err != nil {
+				return err
+			}
+			f.minPts = minPts
 		}
 		f.captured = true
 	}
@@ -65,7 +70,10 @@ func (f *WINDOW_ST_CLUSTERDBSCAN) Done(agg *window.WindowFuncAggregatedStatus) (
 			geos[i] = geographyArg(v)
 		}
 		clusters := dbscanClusters(geos, f.eps, f.minPts)
-		idx := int(agg.RowID - 1)
+		idx, err := helper.SafeInt(agg.RowID - 1)
+		if err != nil {
+			return err
+		}
 		if idx < 0 || idx >= len(clusters) {
 			return nil
 		}

--- a/internal/functions/helper/datetime_time_parser.go
+++ b/internal/functions/helper/datetime_time_parser.go
@@ -548,8 +548,12 @@ func centuryParser(text []rune, t *time.Time) (int, error) {
 	if c < 0 {
 		return 0, fmt.Errorf("invalid century number %d", c)
 	}
+	yearInt, err := SafeInt(c*100 - 99)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
-		int(c*100-99),
+		yearInt,
 		t.Month(),
 		t.Day(),
 		t.Hour(),
@@ -575,8 +579,12 @@ func yearWithoutCenturyParser(text []rune, t *time.Time) (int, error) {
 	} else {
 		year += 2000
 	}
+	yearInt, err := SafeInt(year)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
-		int(year),
+		yearInt,
 		t.Month(),
 		t.Day(),
 		t.Hour(),
@@ -631,10 +639,14 @@ func dayParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse day number: %s", err)
 	}
+	dayInt, err := SafeInt(days)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
 		t.Year(),
 		t.Month(),
-		int(days),
+		dayInt,
 		t.Hour(),
 		t.Minute(),
 		t.Second(),
@@ -675,11 +687,15 @@ func hourParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse hour number: %s", err)
 	}
+	hourInt, err := SafeInt(h)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
 		t.Year(),
 		t.Month(),
 		t.Day(),
-		int(h),
+		hourInt,
 		t.Minute(),
 		t.Second(),
 		t.Nanosecond(),
@@ -724,11 +740,15 @@ func hour12Parser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse hour number: %s", err)
 	}
+	hourInt, err := SafeInt(h)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
 		t.Year(),
 		t.Month(),
 		t.Day(),
-		int(h),
+		hourInt,
 		t.Minute(),
 		t.Second(),
 		t.Nanosecond(),
@@ -746,7 +766,11 @@ func dayOfYearParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse day of year number: %s", err)
 	}
-	dayOfYear := int(d) - 1
+	dInt, err := SafeInt(d)
+	if err != nil {
+		return 0, err
+	}
+	dayOfYear := dInt - 1
 	year := t.Year()
 	stubDate := time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, dayOfYear)
 	*t = time.Date(
@@ -771,12 +795,16 @@ func minuteParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("unexpected minute number: %s", err)
 	}
+	minInt, err := SafeInt(m)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
 		t.Year(),
 		t.Month(),
 		t.Day(),
 		t.Hour(),
-		int(m),
+		minInt,
 		t.Second(),
 		t.Nanosecond(),
 		t.Location(),
@@ -842,9 +870,13 @@ func monthNumberParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse month: %s", err)
 	}
+	monthInt, err := SafeInt(months)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
 		t.Year(),
-		time.Month(months),
+		time.Month(monthInt),
 		t.Day(),
 		t.Hour(),
 		t.Minute(),
@@ -966,13 +998,17 @@ func secondParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("unexpected second number: %s", err)
 	}
+	secInt, err := SafeInt(s)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
 		t.Year(),
 		t.Month(),
 		t.Day(),
 		t.Hour(),
 		t.Minute(),
-		int(s),
+		secInt,
 		t.Nanosecond(),
 		t.Location(),
 	)
@@ -1069,8 +1105,12 @@ func yearParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse year: %s", err)
 	}
+	yearInt, err := SafeInt(y)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
-		int(y),
+		yearInt,
 		t.Month(),
 		t.Day(),
 		t.Hour(),
@@ -1385,7 +1425,10 @@ func timeZoneRFC3339Parser(target []rune, t *time.Time) (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("unexpected hour:minute format: %w", err)
 		}
-		hs := int(h*60*60 + m*60)
+		hs, err := SafeInt(h*60*60 + m*60)
+		if err != nil {
+			return 0, err
+		}
 		if s == '-' {
 			hs *= -1
 		}
@@ -1436,14 +1479,22 @@ func timePrecisionParser(precision int, text []rune, t *time.Time) (int, error) 
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse nanoseconds parameter for %s: %w", string(text), err)
 	}
+	secInt, err := SafeInt(s)
+	if err != nil {
+		return 0, err
+	}
+	nanoInt, err := SafeInt(n)
+	if err != nil {
+		return 0, err
+	}
 	*t = time.Date(
 		t.Year(),
 		t.Month(),
 		t.Day(),
 		t.Hour(),
 		t.Minute(),
-		int(s),
-		int(n),
+		secInt,
+		nanoInt,
 		t.Location(),
 	)
 	return fmtLen, nil

--- a/internal/functions/helper/intconv.go
+++ b/internal/functions/helper/intconv.go
@@ -1,0 +1,46 @@
+package helper
+
+import (
+	"fmt"
+	"math"
+)
+
+// SafeInt converts a 64-bit integer to int. It returns an error when v
+// falls outside the 32-bit range, which is the minimum width the Go
+// specification guarantees for int. Callers use the result as a slice
+// index, length, count, or a date/time component; none of those can
+// legitimately exceed that range, so an out-of-range value is a genuine
+// error rather than a silently truncated conversion.
+func SafeInt(v int64) (int, error) {
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		return 0, fmt.Errorf("integer value %d is out of the supported range [%d, %d]", v, math.MinInt32, math.MaxInt32)
+	}
+	return int(v), nil
+}
+
+// SafeInt32 converts a 64-bit integer to int32, returning an error when
+// v overflows the INT32 range.
+func SafeInt32(v int64) (int32, error) {
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		return 0, fmt.Errorf("integer value %d is out of the INT32 range [%d, %d]", v, math.MinInt32, math.MaxInt32)
+	}
+	return int32(v), nil
+}
+
+// SafeByte converts a 64-bit integer to byte, returning an error when v
+// falls outside the [0, 255] range.
+func SafeByte(v int64) (byte, error) {
+	if v < 0 || v > math.MaxUint8 {
+		return 0, fmt.Errorf("integer value %d is out of the BYTE range [0, 255]", v)
+	}
+	return byte(v), nil
+}
+
+// SafeUint32 converts a 64-bit integer to uint32, returning an error
+// when v falls outside the [0, 4294967295] range.
+func SafeUint32(v int64) (uint32, error) {
+	if v < 0 || v > math.MaxUint32 {
+		return 0, fmt.Errorf("integer value %d is out of the UINT32 range [0, 4294967295]", v)
+	}
+	return uint32(v), nil
+}

--- a/internal/functions/hll/hll_count_init.go
+++ b/internal/functions/hll/hll_count_init.go
@@ -17,7 +17,12 @@ type HLL_COUNT_INIT struct {
 
 func (f *HLL_COUNT_INIT) Step(input value.Value, precision int64, opt *helper.Option) (e error) {
 	f.once.Do(func() {
-		h, err := hll.NewHll(hll.Settings{Log2m: int(precision)})
+		log2m, err := helper.SafeInt(precision)
+		if err != nil {
+			e = err
+			return
+		}
+		h, err := hll.NewHll(hll.Settings{Log2m: log2m})
 		if err != nil {
 			e = err
 		}

--- a/internal/functions/interval/interval.go
+++ b/internal/functions/interval/interval.go
@@ -4,25 +4,30 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
 func INTERVAL(v int64, part string) (value.Value, error) {
+	v32, err := helper.SafeInt32(v)
+	if err != nil {
+		return nil, err
+	}
 	switch part {
 	case "YEAR":
-		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Years: int32(v)}}, nil
+		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Years: v32}}, nil
 	case "MONTH":
-		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Months: int32(v)}}, nil
+		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Months: v32}}, nil
 	case "DAY":
-		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Days: int32(v)}}, nil
+		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Days: v32}}, nil
 	case "HOUR":
-		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Hours: int32(v)}}, nil
+		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Hours: v32}}, nil
 	case "MINUTE":
-		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Minutes: int32(v)}}, nil
+		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Minutes: v32}}, nil
 	case "SECOND":
-		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Seconds: int32(v)}}, nil
+		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{Seconds: v32}}, nil
 	case "NANOSECOND":
-		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{SubSecondNanos: int32(v)}}, nil
+		return &value.IntervalValue{IntervalValue: &bigquery.IntervalValue{SubSecondNanos: v32}}, nil
 	}
 	return nil, fmt.Errorf("unexpected interval part: %s", part)
 }

--- a/internal/functions/interval/make_interval.go
+++ b/internal/functions/interval/make_interval.go
@@ -2,18 +2,43 @@ package interval
 
 import (
 	"cloud.google.com/go/bigquery"
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
 func MAKE_INTERVAL(year, month, day, hour, minute, second int64) (value.Value, error) {
+	year32, err := helper.SafeInt32(year)
+	if err != nil {
+		return nil, err
+	}
+	month32, err := helper.SafeInt32(month)
+	if err != nil {
+		return nil, err
+	}
+	day32, err := helper.SafeInt32(day)
+	if err != nil {
+		return nil, err
+	}
+	hour32, err := helper.SafeInt32(hour)
+	if err != nil {
+		return nil, err
+	}
+	minute32, err := helper.SafeInt32(minute)
+	if err != nil {
+		return nil, err
+	}
+	second32, err := helper.SafeInt32(second)
+	if err != nil {
+		return nil, err
+	}
 	return &value.IntervalValue{
 		IntervalValue: &bigquery.IntervalValue{
-			Years:   int32(year),
-			Months:  int32(month),
-			Days:    int32(day),
-			Hours:   int32(hour),
-			Minutes: int32(minute),
-			Seconds: int32(second),
+			Years:   year32,
+			Months:  month32,
+			Days:    day32,
+			Hours:   hour32,
+			Minutes: minute32,
+			Seconds: second32,
 		},
 	}, nil
 }

--- a/internal/functions/longtail/longtail.go
+++ b/internal/functions/longtail/longtail.go
@@ -256,7 +256,10 @@ func BindSplitSubstr(args ...value.Value) (value.Value, error) {
 		return nil, err
 	}
 	parts := strings.Split(s, delim)
-	idx := int(pos)
+	idx, err := helper.SafeInt(pos)
+	if err != nil {
+		return nil, err
+	}
 	if idx > 0 {
 		idx--
 	} else if idx < 0 {
@@ -273,7 +276,10 @@ func BindSplitSubstr(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		count = int(c)
+		count, err = helper.SafeInt(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if count < 1 {
 		count = 1
@@ -851,7 +857,25 @@ func BindNetFormatIp(args ...value.Value) (value.Value, error) {
 	if n < 0 || n > 0xFFFFFFFF {
 		return nil, fmt.Errorf("NET.FORMAT_IP: out of range")
 	}
-	ip := gonet.IPv4(byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	// Extract each octet by masking to [0, 255] before the checked
+	// byte conversion.
+	b0, err := helper.SafeByte((n >> 24) & 0xFF)
+	if err != nil {
+		return nil, err
+	}
+	b1, err := helper.SafeByte((n >> 16) & 0xFF)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := helper.SafeByte((n >> 8) & 0xFF)
+	if err != nil {
+		return nil, err
+	}
+	b3, err := helper.SafeByte(n & 0xFF)
+	if err != nil {
+		return nil, err
+	}
+	ip := gonet.IPv4(b0, b1, b2, b3)
 	return value.StringValue(ip.String()), nil
 }
 
@@ -921,10 +945,14 @@ func BindNetMakeNet(args ...value.Value) (value.Value, error) {
 	if ip.To4() == nil {
 		bits = 128
 	}
-	if int(pref) < 0 || int(pref) > bits {
+	prefInt, err := helper.SafeInt(pref)
+	if err != nil {
+		return nil, err
+	}
+	if prefInt < 0 || prefInt > bits {
 		return nil, fmt.Errorf("NET.MAKE_NET: prefix out of range")
 	}
-	mask := gonet.CIDRMask(int(pref), bits)
+	mask := gonet.CIDRMask(prefInt, bits)
 	masked := ip.Mask(mask)
 	return value.StringValue(fmt.Sprintf("%s/%d", masked.String(), pref)), nil
 }

--- a/internal/functions/math/log.go
+++ b/internal/functions/math/log.go
@@ -16,7 +16,11 @@ func LOG(x, y value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return value.FloatValue(math.Ldexp(xf, int(yi))), nil
+	yiInt, err := helper.SafeInt(yi)
+	if err != nil {
+		return nil, err
+	}
+	return value.FloatValue(math.Ldexp(xf, yiInt)), nil
 }
 
 var BindLog = helper.ScalarN(func(args ...value.Value) (value.Value, error) {

--- a/internal/functions/math/round.go
+++ b/internal/functions/math/round.go
@@ -26,7 +26,10 @@ var BindRound = helper.ScalarN(func(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		precision = int(i64)
+		precision, err = helper.SafeInt(i64)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return ROUND(args[0], precision)
 })

--- a/internal/functions/net/net_ip_net_mask.go
+++ b/internal/functions/net/net_ip_net_mask.go
@@ -9,7 +9,15 @@ import (
 )
 
 func NET_IP_NET_MASK(output, prefix int64) (value.Value, error) {
-	result := net.CIDRMask(int(prefix), int(output)*8)
+	prefixInt, err := helper.SafeInt(prefix)
+	if err != nil {
+		return nil, err
+	}
+	outputInt, err := helper.SafeInt(output * 8)
+	if err != nil {
+		return nil, err
+	}
+	result := net.CIDRMask(prefixInt, outputInt)
 	if output != 4 && output != 16 {
 		return nil, fmt.Errorf("NET.IP_NET_MASK: the first argument must be either 4 or 16")
 	}

--- a/internal/functions/net/net_ip_trunc.go
+++ b/internal/functions/net/net_ip_trunc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -11,11 +12,15 @@ func NET_IP_TRUNC(v []byte, length int64) (value.Value, error) {
 	if len(v) != 4 && len(v) != 16 {
 		return nil, fmt.Errorf("NET.IP_TRUNC: length of the first argument must be either 4 or 16")
 	}
-	if length < 0 || int(length) > len(v)*8 {
+	lengthInt, err := helper.SafeInt(length)
+	if err != nil {
+		return nil, err
+	}
+	if length < 0 || lengthInt > len(v)*8 {
 		return nil, fmt.Errorf("NET.IP_TRUNC: length must be in the range from 0 to %d", len(v)*8)
 	}
 	ip := net.IP(v)
-	mask := net.CIDRMask(int(length), len(v)*8)
+	mask := net.CIDRMask(lengthInt, len(v)*8)
 	return value.BytesValue(ip.Mask(mask)), nil
 }
 

--- a/internal/functions/net/net_ipv4_from_int64.go
+++ b/internal/functions/net/net_ipv4_from_int64.go
@@ -4,12 +4,25 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
 func NET_IPV4_FROM_INT64(v int64) (value.Value, error) {
+	// GoogleSQL accepts an input in [-0x80000000, 0xFFFFFFFF]: the low
+	// 32 bits hold the address and the upper bits must be a sign
+	// extension of bit 31.
+	if v < -0x80000000 || v > 0xFFFFFFFF {
+		return nil, fmt.Errorf("NET.IPV4_FROM_INT64: %d out of range [-0x80000000, 0xFFFFFFFF]", v)
+	}
+	// Reinterpret the low 32 bits as an unsigned address; masking keeps
+	// the value in [0, 0xFFFFFFFF] for the checked conversion.
+	u32, err := helper.SafeUint32(v & 0xFFFFFFFF)
+	if err != nil {
+		return nil, err
+	}
 	ip := make([]byte, 4)
-	binary.BigEndian.PutUint32(ip, uint32(v))
+	binary.BigEndian.PutUint32(ip, u32)
 	return value.BytesValue(ip), nil
 }
 

--- a/internal/functions/proto/proto.go
+++ b/internal/functions/proto/proto.go
@@ -181,7 +181,11 @@ func BindGetProtoField(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	target := protowire.Number(num)
+	numInt32, err := helper.SafeInt32(num)
+	if err != nil {
+		return nil, err
+	}
+	target := protowire.Number(numInt32)
 	kind, err := args[2].ToString()
 	if err != nil {
 		return nil, err
@@ -267,7 +271,11 @@ func BindGetProtoFieldRepeated(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	target := protowire.Number(num)
+	numInt32, err := helper.SafeInt32(num)
+	if err != nil {
+		return nil, err
+	}
+	target := protowire.Number(numInt32)
 	kind, err := args[2].ToString()
 	if err != nil {
 		return nil, err
@@ -479,7 +487,11 @@ func BindMakeProto(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, encodeSingleField(int(tag), args[i+2], kind)...)
+		tagInt, err := helper.SafeInt(tag)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, encodeSingleField(tagInt, args[i+2], kind)...)
 	}
 	return value.BytesValue(out), nil
 }
@@ -972,7 +984,11 @@ func BindProtoMapContainsKey(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	target := protowire.Number(mapTag)
+	mapTagInt32, err := helper.SafeInt32(mapTag)
+	if err != nil {
+		return nil, err
+	}
+	target := protowire.Number(mapTagInt32)
 	keyKind, err := args[2].ToString()
 	if err != nil {
 		return nil, err
@@ -1056,7 +1072,11 @@ func BindProtoModifyMap(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	mapTag := protowire.Number(mapTagNum)
+	mapTagInt32, err := helper.SafeInt32(mapTagNum)
+	if err != nil {
+		return nil, err
+	}
+	mapTag := protowire.Number(mapTagInt32)
 	keyKind, err := args[2].ToString()
 	if err != nil {
 		return nil, err
@@ -1192,6 +1212,10 @@ func BindEnumValueDescriptorProto(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	nInt32, err := helper.SafeInt32(n)
+	if err != nil {
+		return nil, err
+	}
 	enumName := ""
 	if len(args) >= 2 && args[1] != nil {
 		if s, err := args[1].ToString(); err == nil {
@@ -1199,7 +1223,7 @@ func BindEnumValueDescriptorProto(args ...value.Value) (value.Value, error) {
 		}
 	}
 	out := []byte{}
-	if name := lookupEnumValueName(enumName, int32(n)); name != "" {
+	if name := lookupEnumValueName(enumName, nInt32); name != "" {
 		// field 1 (name) = STRING, wire = BytesType.
 		out = append(out, 0x0a)
 		out = protowire.AppendVarint(out, uint64(len(name)))

--- a/internal/functions/spanner/adddate.go
+++ b/internal/functions/spanner/adddate.go
@@ -36,6 +36,10 @@ func shiftDate(name string, args []value.Value, sign int) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	shifted := gotime.Time(dv).AddDate(0, 0, sign*int(n))
+	days, err := helper.SafeInt(n)
+	if err != nil {
+		return nil, err
+	}
+	shifted := gotime.Time(dv).AddDate(0, 0, sign*days)
 	return value.DateValue(shifted), nil
 }

--- a/internal/functions/spanner/mysql_helpers.go
+++ b/internal/functions/spanner/mysql_helpers.go
@@ -161,7 +161,11 @@ func BindSpace(args ...value.Value) (value.Value, error) {
 	if n < 0 {
 		n = 0
 	}
-	return value.StringValue(strings.Repeat(" ", int(n))), nil
+	count, err := helper.SafeInt(n)
+	if err != nil {
+		return nil, err
+	}
+	return value.StringValue(strings.Repeat(" ", count)), nil
 }
 
 // BindPosition returns the 1-based offset of `needle` within

--- a/internal/functions/spanner/mysql_helpers_extra.go
+++ b/internal/functions/spanner/mysql_helpers_extra.go
@@ -30,7 +30,11 @@ func BindChar(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		b.WriteRune(rune(n))
+		cp, err := helper.SafeInt32(n)
+		if err != nil {
+			return nil, err
+		}
+		b.WriteRune(rune(cp))
 	}
 	return value.StringValue(b.String()), nil
 }
@@ -89,11 +93,19 @@ func BindInsert(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	if pos <= 0 || int(pos) > len(src) {
+	posInt, err := helper.SafeInt(pos)
+	if err != nil {
+		return nil, err
+	}
+	if pos <= 0 || posInt > len(src) {
 		return value.StringValue(src), nil
 	}
-	start := int(pos - 1)
-	end := start + int(length)
+	start := posInt - 1
+	lengthInt, err := helper.SafeInt(length)
+	if err != nil {
+		return nil, err
+	}
+	end := start + lengthInt
 	if length < 0 || end > len(src) {
 		end = len(src)
 	}
@@ -124,7 +136,11 @@ func BindLocate(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		start = int(s) - 1
+		sInt, err := helper.SafeInt(s)
+		if err != nil {
+			return nil, err
+		}
+		start = sInt - 1
 		if start < 0 {
 			start = 0
 		}
@@ -155,9 +171,13 @@ func BindMid(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	start := int(pos) - 1
+	posInt, err := helper.SafeInt(pos)
+	if err != nil {
+		return nil, err
+	}
+	start := posInt - 1
 	if pos < 0 {
-		start = len(s) + int(pos)
+		start = len(s) + posInt
 	}
 	if start < 0 {
 		start = 0
@@ -171,10 +191,14 @@ func BindMid(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		if int(l) < 0 {
+		lInt, err := helper.SafeInt(l)
+		if err != nil {
+			return nil, err
+		}
+		if lInt < 0 {
 			return value.StringValue(""), nil
 		}
-		end = start + int(l)
+		end = start + lInt
 		if end > len(s) {
 			end = len(s)
 		}
@@ -324,12 +348,19 @@ func BindSubstringIndex(args ...value.Value) (value.Value, error) {
 	}
 	parts := strings.Split(s, delim)
 	if count > 0 {
-		if int(count) >= len(parts) {
+		c, err := helper.SafeInt(count)
+		if err != nil {
+			return nil, err
+		}
+		if c >= len(parts) {
 			return value.StringValue(s), nil
 		}
-		return value.StringValue(strings.Join(parts[:count], delim)), nil
+		return value.StringValue(strings.Join(parts[:c], delim)), nil
 	}
-	n := int(-count)
+	n, err := helper.SafeInt(-count)
+	if err != nil {
+		return nil, err
+	}
 	if n >= len(parts) {
 		return value.StringValue(s), nil
 	}
@@ -424,7 +455,11 @@ func BindFromDays(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	d := mysqlUnixEpochAsTime.AddDate(0, 0, int(n-mysqlDaysFromYear0ToUnixEpoch))
+	dayOffset, err := helper.SafeInt(n - mysqlDaysFromYear0ToUnixEpoch)
+	if err != nil {
+		return nil, err
+	}
+	d := mysqlUnixEpochAsTime.AddDate(0, 0, dayOffset)
 	return value.DateValue(d), nil
 }
 
@@ -482,7 +517,15 @@ func BindMakeDate(args ...value.Value) (value.Value, error) {
 	if doy < 1 {
 		return nil, nil
 	}
-	d := time.Date(int(year), 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, int(doy-1))
+	yearInt, err := helper.SafeInt(year)
+	if err != nil {
+		return nil, err
+	}
+	doyOffset, err := helper.SafeInt(doy - 1)
+	if err != nil {
+		return nil, err
+	}
+	d := time.Date(yearInt, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, doyOffset)
 	return value.DateValue(d), nil
 }
 
@@ -534,8 +577,15 @@ func BindPeriodAdd(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	y, m := splitPeriod(p)
-	tm := time.Date(y, time.Month(m), 1, 0, 0, 0, 0, time.UTC).AddDate(0, int(n), 0)
+	y, m, err := splitPeriod(p)
+	if err != nil {
+		return nil, err
+	}
+	months, err := helper.SafeInt(n)
+	if err != nil {
+		return nil, err
+	}
+	tm := time.Date(y, time.Month(m), 1, 0, 0, 0, 0, time.UTC).AddDate(0, months, 0)
 	return value.IntValue(int64(tm.Year())*100 + int64(tm.Month())), nil
 }
 
@@ -555,27 +605,47 @@ func BindPeriodDiff(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	ay, am := splitPeriod(a)
-	by, bm := splitPeriod(b)
+	ay, am, err := splitPeriod(a)
+	if err != nil {
+		return nil, err
+	}
+	by, bm, err := splitPeriod(b)
+	if err != nil {
+		return nil, err
+	}
 	return value.IntValue(int64((ay-by)*12 + (am - bm))), nil
 }
 
-func splitPeriod(p int64) (int, int) {
+func splitPeriod(p int64) (int, int, error) {
 	if p < 1 {
-		return 0, 0
+		return 0, 0, nil
 	}
 	if p < 7000 {
 		// MySQL convention: 2-digit year < 70 → 20xx, else 19xx.
-		yy := int(p / 100)
-		mm := int(p % 100)
+		yy, err := helper.SafeInt(p / 100)
+		if err != nil {
+			return 0, 0, err
+		}
+		mm, err := helper.SafeInt(p % 100)
+		if err != nil {
+			return 0, 0, err
+		}
 		if yy < 70 {
 			yy += 2000
 		} else {
 			yy += 1900
 		}
-		return yy, mm
+		return yy, mm, nil
 	}
-	return int(p / 100), int(p % 100)
+	yy, err := helper.SafeInt(p / 100)
+	if err != nil {
+		return 0, 0, err
+	}
+	mm, err := helper.SafeInt(p % 100)
+	if err != nil {
+		return 0, 0, err
+	}
+	return yy, mm, nil
 }
 
 // BindStrToDate parses a STRING using a MySQL date format string.
@@ -738,7 +808,14 @@ func BindInetNtoa(args ...value.Value) (value.Value, error) {
 	if n < 0 || n > 0xFFFFFFFF {
 		return nil, nil
 	}
-	ip := net.IPv4(byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	// n is range-checked to [0, 0xFFFFFFFF] above, so the conversion to
+	// uint32 is exact. Each octet is then the low 8 bits of a shift,
+	// which is the intended IPv4 dotted-quad decomposition.
+	u, err := helper.SafeUint32(n)
+	if err != nil {
+		return nil, err
+	}
+	ip := net.IPv4(byte(u>>24), byte(u>>16), byte(u>>8), byte(u))
 	return value.StringValue(ip.String()), nil
 }
 

--- a/internal/functions/spanner/search.go
+++ b/internal/functions/spanner/search.go
@@ -119,7 +119,10 @@ func BindSpannerTokenizeNGrams(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		n = int(x)
+		n, err = helper.SafeInt(x)
+		if err != nil {
+			return nil, err
+		}
 		if n < 1 {
 			n = 1
 		}

--- a/internal/functions/string/chr.go
+++ b/internal/functions/string/chr.go
@@ -9,7 +9,11 @@ func CHR(v int64) (value.Value, error) {
 	if v == 0 {
 		return value.StringValue(""), nil
 	}
-	return value.StringValue(string(rune(v))), nil
+	r, err := helper.SafeInt32(v)
+	if err != nil {
+		return nil, err
+	}
+	return value.StringValue(string(rune(r))), nil
 }
 
 var BindChr = helper.Scalar1(func(a value.Value) (value.Value, error) {

--- a/internal/functions/string/code_points_to_bytes.go
+++ b/internal/functions/string/code_points_to_bytes.go
@@ -12,7 +12,11 @@ func CODE_POINTS_TO_BYTES(v *value.ArrayValue) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		b = append(b, byte(i64))
+		bv, err := helper.SafeByte(i64)
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, bv)
 	}
 	return value.BytesValue(b), nil
 }

--- a/internal/functions/string/code_points_to_string.go
+++ b/internal/functions/string/code_points_to_string.go
@@ -18,7 +18,11 @@ func CODE_POINTS_TO_STRING(v *value.ArrayValue) (value.Value, error) {
 		if i64 == 0 {
 			continue
 		}
-		runes = append(runes, rune(i64))
+		r, err := helper.SafeInt32(i64)
+		if err != nil {
+			return nil, err
+		}
+		runes = append(runes, rune(r))
 	}
 	return value.StringValue(string(runes)), nil
 }

--- a/internal/functions/string/function_format.go
+++ b/internal/functions/string/function_format.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-json"
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -177,8 +178,10 @@ func parseInteger(param *FormatParam, args []value.Value) ([]rune, error) {
 	if param.flag == FormatFlagZero {
 		format += "0"
 	}
-	var width int
-	width, args = param.width.format(args)
+	width, args, err := param.width.format(args)
+	if err != nil {
+		return nil, err
+	}
 	if width > 0 {
 		format += fmt.Sprint(width)
 	}
@@ -232,11 +235,14 @@ func parseInteger(param *FormatParam, args []value.Value) ([]rune, error) {
 }
 
 func parseFloat(param *FormatParam, args []value.Value) ([]rune, error) {
-	var (
-		width, precision int
-	)
-	width, args = param.width.format(args)
-	precision, args = param.precision.format(args)
+	width, args, err := param.width.format(args)
+	if err != nil {
+		return nil, err
+	}
+	precision, args, err := param.precision.format(args)
+	if err != nil {
+		return nil, err
+	}
 	v, err := args[0].ToFloat64()
 	if err != nil {
 		return nil, err
@@ -385,21 +391,25 @@ type FormatWidth struct {
 	fromArg bool
 }
 
-func (w *FormatWidth) format(args []value.Value) (int, []value.Value) {
+func (w *FormatWidth) format(args []value.Value) (int, []value.Value, error) {
 	if w == nil {
-		return 0, args
+		return 0, args, nil
 	}
 	if w.fromArg {
 		width, _ := args[0].ToInt64()
 		if width <= 0 {
-			return 0, args[1:]
+			return 0, args[1:], nil
 		}
-		return int(width), args[1:]
+		n, err := helper.SafeInt(width)
+		if err != nil {
+			return 0, args[1:], err
+		}
+		return n, args[1:], nil
 	}
 	if w.num <= 0 {
-		return 0, args
+		return 0, args, nil
 	}
-	return w.num, args
+	return w.num, args, nil
 }
 
 type FormatPrecision struct {
@@ -407,21 +417,25 @@ type FormatPrecision struct {
 	fromArg bool
 }
 
-func (p *FormatPrecision) format(args []value.Value) (int, []value.Value) {
+func (p *FormatPrecision) format(args []value.Value) (int, []value.Value, error) {
 	if p == nil {
-		return 6, args
+		return 6, args, nil
 	}
 	if p.fromArg {
 		precision, _ := args[0].ToInt64()
 		if precision <= 0 {
-			return -1, args[1:]
+			return -1, args[1:], nil
 		}
-		return int(precision), args[1:]
+		n, err := helper.SafeInt(precision)
+		if err != nil {
+			return -1, args[1:], err
+		}
+		return n, args[1:], nil
 	}
 	if p.num <= 0 {
-		return -1, args
+		return -1, args, nil
 	}
-	return p.num, args
+	return p.num, args, nil
 }
 
 func parseFormat(format string, args ...value.Value) (string, error) {
@@ -527,7 +541,11 @@ func parseFormatWidth(ctx *FormatContext) (*FormatWidth, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &FormatWidth{num: int(i64)}, nil
+		num, err := helper.SafeInt(i64)
+		if err != nil {
+			return nil, err
+		}
+		return &FormatWidth{num: num}, nil
 	}
 	return nil, nil
 }
@@ -556,7 +574,11 @@ func parseFormatPrecision(ctx *FormatContext) (*FormatPrecision, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &FormatPrecision{num: int(i64)}, nil
+		num, err := helper.SafeInt(i64)
+		if err != nil {
+			return nil, err
+		}
+		return &FormatPrecision{num: num}, nil
 	}
 	return nil, nil
 }

--- a/internal/functions/string/left.go
+++ b/internal/functions/string/left.go
@@ -11,6 +11,10 @@ func LEFT(v value.Value, length int64) (value.Value, error) {
 	if length < 0 {
 		return nil, fmt.Errorf("LEFT: unexpected length value. length must be positive number")
 	}
+	n, err := helper.SafeInt(length)
+	if err != nil {
+		return nil, err
+	}
 	switch v.(type) {
 	case value.StringValue:
 		s, err := v.ToString()
@@ -18,19 +22,19 @@ func LEFT(v value.Value, length int64) (value.Value, error) {
 			return nil, err
 		}
 		runes := []rune(s)
-		if len(runes) <= int(length) {
+		if len(runes) <= n {
 			return v, nil
 		}
-		return value.StringValue(string(runes[:length])), nil
+		return value.StringValue(string(runes[:n])), nil
 	case value.BytesValue:
 		b, err := v.ToBytes()
 		if err != nil {
 			return nil, err
 		}
-		if len(b) <= int(length) {
+		if len(b) <= n {
 			return v, nil
 		}
-		return value.BytesValue(b[:length]), nil
+		return value.BytesValue(b[:n]), nil
 	}
 	return nil, fmt.Errorf("LEFT: value type is must be STRING or BYTES type")
 }

--- a/internal/functions/string/lpad.go
+++ b/internal/functions/string/lpad.go
@@ -10,6 +10,10 @@ import (
 )
 
 func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (value.Value, error) {
+	retLen, err := helper.SafeInt(returnLength)
+	if err != nil {
+		return nil, err
+	}
 	switch originalValue.(type) {
 	case value.StringValue:
 		s, err := originalValue.ToString()
@@ -17,10 +21,10 @@ func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 			return nil, err
 		}
 		runes := []rune(s)
-		if len(runes) >= int(returnLength) {
-			return value.StringValue(string(runes[:returnLength])), nil
+		if len(runes) >= retLen {
+			return value.StringValue(string(runes[:retLen])), nil
 		}
-		remainLen := int(returnLength) - len(runes)
+		remainLen := retLen - len(runes)
 		var pat []rune
 		if pattern == nil {
 			pat = []rune(strings.Repeat(" ", remainLen))
@@ -42,10 +46,10 @@ func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if err != nil {
 			return nil, err
 		}
-		if len(b) >= int(returnLength) {
-			return value.BytesValue(b[:returnLength]), nil
+		if len(b) >= retLen {
+			return value.BytesValue(b[:retLen]), nil
 		}
-		remainLen := int(returnLength) - len(b)
+		remainLen := retLen - len(b)
 		var pat []byte
 		if pattern == nil {
 			pat = bytes.Repeat([]byte{' '}, remainLen)

--- a/internal/functions/string/regexp_extract.go
+++ b/internal/functions/string/regexp_extract.go
@@ -19,7 +19,15 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 	if err != nil {
 		return nil, err
 	}
-	pos := int(position) - 1
+	posInt, err := helper.SafeInt(position)
+	if err != nil {
+		return nil, err
+	}
+	pos := posInt - 1
+	occ, err := helper.SafeInt(occurrence)
+	if err != nil {
+		return nil, err
+	}
 	switch val.(type) {
 	case value.StringValue:
 		v, err := val.ToString()
@@ -29,11 +37,11 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if pos >= len([]rune(v)) {
 			return nil, nil
 		}
-		matches := re.FindAllStringSubmatch(v[pos:], int(occurrence))
-		if len(matches) < int(occurrence) {
+		matches := re.FindAllStringSubmatch(v[pos:], occ)
+		if len(matches) < occ {
 			return nil, nil
 		}
-		match := matches[occurrence-1]
+		match := matches[occ-1]
 		return value.StringValue(match[len(match)-1]), nil
 	case value.BytesValue:
 		v, err := val.ToBytes()
@@ -43,11 +51,11 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if pos >= len(v) {
 			return nil, nil
 		}
-		matches := re.FindAllSubmatch(v[pos:], int(occurrence))
-		if len(matches) < int(occurrence) {
+		matches := re.FindAllSubmatch(v[pos:], occ)
+		if len(matches) < occ {
 			return nil, nil
 		}
-		match := matches[occurrence-1]
+		match := matches[occ-1]
 		return value.BytesValue(match[len(match)-1]), nil
 	}
 	return nil, fmt.Errorf("REGEXP_EXTRACT: val argument must be STRING or BYTES")

--- a/internal/functions/string/regexp_instr.go
+++ b/internal/functions/string/regexp_instr.go
@@ -15,7 +15,19 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 	if occurrence <= 0 {
 		return nil, fmt.Errorf("REGEXP_INSTR: unexpected occurrence number. occurrence must be positive number")
 	}
-	pos := int(position) - 1
+	posInt, err := helper.SafeInt(position)
+	if err != nil {
+		return nil, err
+	}
+	pos := posInt - 1
+	occ, err := helper.SafeInt(occurrence)
+	if err != nil {
+		return nil, err
+	}
+	occPos, err := helper.SafeInt(occurrencePos)
+	if err != nil {
+		return nil, err
+	}
 	switch sourceValue.(type) {
 	case value.StringValue:
 		source, err := sourceValue.ToString()
@@ -33,15 +45,15 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 		if pos >= len([]rune(source)) {
 			return value.IntValue(0), nil
 		}
-		matches := re.FindAllStringSubmatchIndex(source[pos:], int(occurrence))
-		if len(matches) < int(occurrence) {
+		matches := re.FindAllStringSubmatchIndex(source[pos:], occ)
+		if len(matches) < occ {
 			return value.IntValue(0), nil
 		}
-		match := matches[occurrence-1]
-		if len(match) <= int(occurrencePos) {
+		match := matches[occ-1]
+		if len(match) <= occPos {
 			return value.IntValue(0), nil
 		}
-		return value.IntValue(pos + match[occurrencePos] + 1), nil
+		return value.IntValue(pos + match[occPos] + 1), nil
 	case value.BytesValue:
 		source, err := sourceValue.ToBytes()
 		if err != nil {
@@ -58,15 +70,15 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 		if pos >= len(source) {
 			return value.IntValue(0), nil
 		}
-		matches := re.FindAllSubmatchIndex(source[pos:], int(occurrence))
-		if len(matches) < int(occurrence) {
+		matches := re.FindAllSubmatchIndex(source[pos:], occ)
+		if len(matches) < occ {
 			return value.IntValue(0), nil
 		}
-		match := matches[occurrence-1]
-		if len(match) <= int(occurrencePos) {
+		match := matches[occ-1]
+		if len(match) <= occPos {
 			return value.IntValue(0), nil
 		}
-		return value.IntValue(pos + match[occurrencePos] + 1), nil
+		return value.IntValue(pos + match[occPos] + 1), nil
 	}
 	return nil, fmt.Errorf("REGEXP_INSTR: source value must be STRING or BYTES")
 }

--- a/internal/functions/string/repeat.go
+++ b/internal/functions/string/repeat.go
@@ -10,19 +10,23 @@ import (
 )
 
 func REPEAT(originalValue value.Value, repetitions int64) (value.Value, error) {
+	reps, err := helper.SafeInt(repetitions)
+	if err != nil {
+		return nil, err
+	}
 	switch originalValue.(type) {
 	case value.StringValue:
 		v, err := originalValue.ToString()
 		if err != nil {
 			return nil, err
 		}
-		return value.StringValue(strings.Repeat(v, int(repetitions))), nil
+		return value.StringValue(strings.Repeat(v, reps)), nil
 	case value.BytesValue:
 		v, err := originalValue.ToBytes()
 		if err != nil {
 			return nil, err
 		}
-		return value.BytesValue(bytes.Repeat(v, int(repetitions))), nil
+		return value.BytesValue(bytes.Repeat(v, reps)), nil
 	}
 	return nil, fmt.Errorf("REPEAT: originalValue must be STRING or BYTES")
 }

--- a/internal/functions/string/right.go
+++ b/internal/functions/string/right.go
@@ -11,6 +11,10 @@ func RIGHT(val value.Value, length int64) (value.Value, error) {
 	if length < 0 {
 		return nil, fmt.Errorf("RIGHT: unexpected length val. length must be positive number")
 	}
+	n, err := helper.SafeInt(length)
+	if err != nil {
+		return nil, err
+	}
 	switch val.(type) {
 	case value.StringValue:
 		v, err := val.ToString()
@@ -18,19 +22,19 @@ func RIGHT(val value.Value, length int64) (value.Value, error) {
 			return nil, err
 		}
 		runes := []rune(v)
-		if len(runes) <= int(length) {
+		if len(runes) <= n {
 			return val, nil
 		}
-		return value.StringValue(string(runes[len(runes)-int(length):])), nil
+		return value.StringValue(string(runes[len(runes)-n:])), nil
 	case value.BytesValue:
 		v, err := val.ToBytes()
 		if err != nil {
 			return nil, err
 		}
-		if len(v) <= int(length) {
+		if len(v) <= n {
 			return val, nil
 		}
-		return value.BytesValue(v[len(v)-int(length):]), nil
+		return value.BytesValue(v[len(v)-n:]), nil
 	}
 	return nil, fmt.Errorf("RIGHT: val must be STRING or BYTES")
 }

--- a/internal/functions/string/rpad.go
+++ b/internal/functions/string/rpad.go
@@ -13,6 +13,10 @@ func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 	if returnLength < 0 {
 		return nil, fmt.Errorf("RPAD: unexpected returnLength value. returnLength must be positive number")
 	}
+	retLen, err := helper.SafeInt(returnLength)
+	if err != nil {
+		return nil, err
+	}
 	switch originalValue.(type) {
 	case value.StringValue:
 		v, err := originalValue.ToString()
@@ -20,10 +24,10 @@ func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 			return nil, err
 		}
 		runes := []rune(v)
-		if len(runes) >= int(returnLength) {
-			return value.StringValue(string(runes[:returnLength])), nil
+		if len(runes) >= retLen {
+			return value.StringValue(string(runes[:retLen])), nil
 		}
-		remainLen := int(returnLength) - len(runes)
+		remainLen := retLen - len(runes)
 		var pat []rune
 		if pattern == nil {
 			pat = []rune(strings.Repeat(" ", remainLen))
@@ -45,10 +49,10 @@ func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if err != nil {
 			return nil, err
 		}
-		if len(v) >= int(returnLength) {
-			return value.BytesValue(v[:returnLength]), nil
+		if len(v) >= retLen {
+			return value.BytesValue(v[:retLen]), nil
 		}
-		remainLen := int(returnLength) - len(v)
+		remainLen := retLen - len(v)
 		var pat []byte
 		if pattern == nil {
 			pat = bytes.Repeat([]byte{' '}, remainLen)

--- a/internal/functions/structs/struct_field.go
+++ b/internal/functions/structs/struct_field.go
@@ -28,5 +28,9 @@ var BindStructField = helper.Scalar2(func(a, b value.Value) (value.Value, error)
 	if err != nil {
 		return nil, err
 	}
-	return STRUCT_FIELD(a, int(i64))
+	idx, err := helper.SafeInt(i64)
+	if err != nil {
+		return nil, err
+	}
+	return STRUCT_FIELD(a, idx)
 })

--- a/internal/functions/structs/struct_with_field_set.go
+++ b/internal/functions/structs/struct_with_field_set.go
@@ -3,6 +3,7 @@ package structs
 import (
 	"fmt"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -50,5 +51,9 @@ func BindStructWithFieldSet(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return STRUCT_WITH_FIELD_SET(args[0], int(idx), args[2])
+	idxInt, err := helper.SafeInt(idx)
+	if err != nil {
+		return nil, err
+	}
+	return STRUCT_WITH_FIELD_SET(args[0], idxInt, args[2])
 }

--- a/internal/functions/time/time.go
+++ b/internal/functions/time/time.go
@@ -26,7 +26,19 @@ func TIME(args ...value.Value) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		return value.TimeValue(time.Date(0, 0, 0, int(hour), int(min), int(sec), 0, loc)), nil
+		hourInt, err := helper.SafeInt(hour)
+		if err != nil {
+			return nil, err
+		}
+		minInt, err := helper.SafeInt(min)
+		if err != nil {
+			return nil, err
+		}
+		secInt, err := helper.SafeInt(sec)
+		if err != nil {
+			return nil, err
+		}
+		return value.TimeValue(time.Date(0, 0, 0, hourInt, minInt, secInt, 0, loc)), nil
 	}
 	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("TIME: invalid number of arguments: got %d, want 1 or 2", len(args))

--- a/internal/functions/timestamp/timestamp_add.go
+++ b/internal/functions/timestamp/timestamp_add.go
@@ -21,7 +21,11 @@ func TIMESTAMP_ADD(t time.Time, v int64, part string) (value.Value, error) {
 	case "HOUR":
 		return value.TimestampValue(t.Add(time.Duration(v) * time.Hour)), nil
 	case "DAY":
-		return value.TimestampValue(t.AddDate(0, 0, int(v))), nil
+		n, err := helper.SafeInt(v)
+		if err != nil {
+			return nil, err
+		}
+		return value.TimestampValue(t.AddDate(0, 0, n)), nil
 	}
 	return nil, fmt.Errorf("TIMESTAMP_ADD: unexpected part value %s", part)
 }

--- a/internal/functions/timestamp/timestamp_sub.go
+++ b/internal/functions/timestamp/timestamp_sub.go
@@ -21,7 +21,11 @@ func TIMESTAMP_SUB(t time.Time, v int64, part string) (value.Value, error) {
 	case "HOUR":
 		return value.TimestampValue(t.Add(-time.Duration(v) * time.Hour)), nil
 	case "DAY":
-		return value.TimestampValue(t.AddDate(0, 0, -int(v))), nil
+		n, err := helper.SafeInt(v)
+		if err != nil {
+			return nil, err
+		}
+		return value.TimestampValue(t.AddDate(0, 0, -n)), nil
 	}
 	return nil, fmt.Errorf("TIMESTAMP_SUB: unexpected part value %s", part)
 }

--- a/internal/functions/window/funcs.go
+++ b/internal/functions/window/funcs.go
@@ -9,6 +9,7 @@ import (
 
 	"gonum.org/v1/gonum/stat"
 
+	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -677,7 +678,11 @@ func (f *WINDOW_PERCENTILE_CONT) Done(agg *WindowFuncAggregatedStatus) (value.Va
 			if err != nil {
 				return err
 			}
-			nonNullValues = append(nonNullValues, int(int64Val))
+			intVal, err := helper.SafeInt(int64Val)
+			if err != nil {
+				return err
+			}
+			nonNullValues = append(nonNullValues, intVal)
 			filteredValues = append(filteredValues, val)
 		}
 		if len(filteredValues) == 0 {

--- a/internal/value/location.go
+++ b/internal/value/location.go
@@ -40,11 +40,14 @@ func toLocation(timeZone string) (*time.Location, error) {
 	if matched := timeZoneOffsetPattern.FindAllStringSubmatch(timeZone, -1); len(matched) != 0 && len(matched[0]) == 3 {
 		offsetHour := matched[0][1]
 		offsetMin := matched[0][2]
-		hour, err := strconv.ParseInt(offsetHour, 10, 64)
+		// The regexp captures at most a sign plus two digits, so the
+		// parsed values always fit in 32 bits; parsing with a 32-bit
+		// width keeps the int conversions below provably in range.
+		hour, err := strconv.ParseInt(offsetHour, 10, 32)
 		if err != nil {
 			return nil, err
 		}
-		min, err := strconv.ParseInt(offsetMin, 10, 64)
+		min, err := strconv.ParseInt(offsetMin, 10, 32)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +58,7 @@ func toLocation(timeZone string) (*time.Location, error) {
 	}
 	if matched := timeZoneOffsetPartialPattern.FindAllStringSubmatch(timeZone, -1); len(matched) != 0 && len(matched[0]) == 2 {
 		offset := matched[0][1]
-		hour, err := strconv.ParseInt(offset, 10, 64)
+		hour, err := strconv.ParseInt(offset, 10, 32)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Resolves all 132 open code-scanning alerts.

## `go/incorrect-integer-conversion` (129 alerts)

Every alert flagged a 64-bit integer (ultimately from `strconv.ParseInt` via `Value.ToInt64()`) converted to a narrower type — `int`, `int32`, `byte`, `rune`, `uint32` — with no range check, so an overflowing value would silently truncate.

- Added `internal/functions/helper/intconv.go` with range-checked converters `SafeInt` / `SafeInt32` / `SafeByte` / `SafeUint32`. Each performs the bounds check before the narrowing conversion, returning an error on overflow.
- Routed all 129 flagged conversions across 46 function files through these helpers.
- `internal/value/location.go` parses time-zone offsets with a 32-bit width, since the regexp only captures a sign plus two digits.
- `NET.IPV4_FROM_INT64` and `BIT_CAST_TO_INT32` keep their low-32-bit reinterpretation semantics: the input is range-checked per the GoogleSQL spec, then masked before the checked unsigned conversion.

## `actions/missing-workflow-permissions` (3 alerts)

Added a top-level `permissions: contents: read` block to `.github/workflows/ci.yml` — all jobs are read-only.

## Verification

- `go build ./...`, `go vet ./internal/...` — clean
- `make lint` — 0 issues
- `make identity-check` — clean
- Full `go test -timeout 30m ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)