### PR TITLE
Speed up the CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # cache: false — setup-go's built-in cache keys solely on go.sum,
+      # so all three jobs (test/lint/validate) collide on one immutable
+      # key. The shortest job wins the post-step save and freezes a
+      # near-empty (~16 MB) snapshot for everyone. We manage the module
+      # and build caches explicitly below with per-job keys instead.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
+
+      # The module cache only changes when go.sum does, so an
+      # immutable per-job key is fine.
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-test-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-test-${{ runner.os }}-
+
+      # The build cache holds the -race-instrumented object files,
+      # which are expensive to recompile and live in a separate
+      # namespace from the non-race `make build` output. The key
+      # carries the commit SHA so every run misses the primary key and
+      # the post-step always re-saves a fresh cache (the GitHub Actions
+      # cache is immutable — a hit never updates). restore-keys then
+      # restores the most recent cache for the same go.sum.
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-build-test-${{ runner.os }}-
 
       # Persist the wazero compilation cache across runs. The cache is
       # keyed on go.sum (the embedded wasm only changes when the
@@ -57,6 +89,37 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
+
+      # tools/go.sum pins golangci-lint itself, so the module cache key
+      # tracks both module graphs.
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-lint-${{ runner.os }}-${{ hashFiles('go.sum', 'tools/go.sum') }}
+          restore-keys: |
+            go-mod-lint-${{ runner.os }}-
+
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-lint-${{ runner.os }}-${{ hashFiles('go.sum', 'tools/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-lint-${{ runner.os }}-${{ hashFiles('go.sum', 'tools/go.sum') }}-
+            go-build-lint-${{ runner.os }}-
+
+      # golangci-lint keeps its own analysis cache separate from the Go
+      # build cache; persisting it avoids re-running every linter from
+      # scratch on each push.
+      - name: Cache golangci-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('go.sum', 'tools/go.sum', '.golangci.yml', '.golangci.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            golangci-lint-${{ runner.os }}-
 
       - name: Lint
         run: make lint
@@ -71,6 +134,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Validate
         run: make validate

--- a/ddl_test.go
+++ b/ddl_test.go
@@ -19,6 +19,7 @@ import (
 // Source: database/sql.Conn.QueryContext is documented to accept any
 // SQL string; the driver shouldn't refuse DDL.
 func TestDDLViaQueryContext(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=ddl_via_query")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -96,6 +97,7 @@ func TestDDLViaQueryContext(t *testing.T) {
 // NoopStmtAction. Calling it via db.QueryContext exercises the
 // QueryContext branch (rather than ExecContext).
 func TestNoopDDLViaQueryContext(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=noop_querycontext")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -125,6 +127,7 @@ func TestNoopDDLViaQueryContext(t *testing.T) {
 // TestBeginCommitViaQueryContext drives BeginStmtAction.QueryContext
 // and CommitStmtAction.QueryContext through db.QueryContext.
 func TestBeginCommitViaQueryContext(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=begin_commit_qc")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -147,6 +150,7 @@ func TestBeginCommitViaQueryContext(t *testing.T) {
 
 // TestTruncateViaQueryContext drives TruncateStmtAction.QueryContext.
 func TestTruncateViaQueryContext(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=truncate_qc")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -177,6 +181,7 @@ func TestTruncateViaQueryContext(t *testing.T) {
 
 // TestMergeViaQueryContext drives MergeStmtAction.QueryContext.
 func TestMergeViaQueryContext(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=merge_qc")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -221,6 +226,7 @@ func TestMergeViaQueryContext(t *testing.T) {
 // TestAssignmentViaQueryContext drives AssignmentStmtAction.QueryContext
 // for `SET @@var = expr`.
 func TestAssignmentViaQueryContext(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=assign_qc")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -263,6 +269,7 @@ func TestAssignmentViaQueryContext(t *testing.T) {
 // does not mutate SQLite state). The contract assertion is that
 // Exec returns nil error.
 func TestNoopDDLAlterTable(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=noop_alter_table")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -294,6 +301,7 @@ func TestNoopDDLAlterTable(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-definition-language.md
 // "CREATE SCHEMA" grammar.
 func TestNoopDDLCreateSchema(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=noop_create_schema")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -319,6 +327,7 @@ func TestNoopDDLCreateSchema(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-control-language.md
 // "GRANT" / "REVOKE" sections.
 func TestNoopDDLGrantRevoke(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=noop_grant_revoke")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -352,6 +361,7 @@ func TestNoopDDLGrantRevoke(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/procedural-language.md
 // "CREATE PROCEDURE" grammar.
 func TestNoopDDLCreateProcedure(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=noop_create_procedure")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -376,6 +386,7 @@ func TestNoopDDLCreateProcedure(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-manipulation-language.md
 // "ASSERT" / procedural-language ASSERT grammar.
 func TestNoopDDLAssertStmt(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=noop_assert")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -410,6 +421,7 @@ func TestNoopDDLAssertStmt(t *testing.T) {
 // DescriptorPool and replays its registered protos / enums on the
 // fresh SimpleCatalog instance.
 func TestDropDoesNotWipeWellKnownProtos(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=drop_preserves_protos")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -458,6 +470,7 @@ func TestDropDoesNotWipeWellKnownProtos(t *testing.T) {
 // "CREATE PROPERTY GRAPH" grammar and the `FinGraph` Examples
 // section.
 func TestCreatePropertyGraph(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=create_property_graph")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -525,6 +538,7 @@ func TestCreatePropertyGraph(t *testing.T) {
 // FinGraph example (lines 472-499 of that file). Expected: the
 // Person rows we inserted come back unfiltered.
 func TestPropertyGraphMatchPerson(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=property_graph_match_person")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -593,6 +607,7 @@ func TestPropertyGraphMatchPerson(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/graph-schema-statements.md
 // FinGraph EDGE TABLES + graph-query-statements MATCH (a)-[e]->(b).
 func TestPropertyGraphMatchEdge(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=property_graph_match_edge")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -658,6 +673,7 @@ func TestPropertyGraphMatchEdge(t *testing.T) {
 // TABLE FUNCTION" with the TEMP modifier — function only exists for
 // the current session.
 func TestTempTVF(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=tvf_temp")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -715,6 +731,7 @@ func TestTempTVF(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-definition-language.md
 // "DROP" statements.
 func TestDropTableAndFunction(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=drop_table_fn")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -746,6 +763,7 @@ func TestDropTableAndFunction(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-definition-language.md
 // "DROP VIEW".
 func TestDropView(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=drop_view")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -768,6 +786,7 @@ func TestDropView(t *testing.T) {
 // CREATE FUNCTION inside a dataset namespace yields a multi-part
 // NamePath, which exercises getFunctions/getTVFs lookup branches.
 func TestNamePathedFunction(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=ns_func")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -799,6 +818,7 @@ func TestNamePathedFunction(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-manipulation-language.md
 // "TRUNCATE TABLE".
 func TestExecContextTruncate(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=truncate")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -832,6 +852,7 @@ func TestExecContextTruncate(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-manipulation-language.md
 // "MERGE" statement.
 func TestMergeStmt(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=merge")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -878,6 +899,7 @@ func TestMergeStmt(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/user-defined-functions.md
 // "ANY TYPE" — templated function parameter.
 func TestTemplatedFunctionAnyType(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=templated_any_type")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -918,6 +940,7 @@ func TestTemplatedFunctionAnyType(t *testing.T) {
 // typeKindToSQLName for primitive kinds. Source:
 // docs/third_party/googlesql-docs/conversion_functions.md "CAST".
 func TestCastEveryTypeFormatType(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=cast_format_type")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)

--- a/dml_test.go
+++ b/dml_test.go
@@ -32,6 +32,7 @@ import (
 // join condition, exercising newMergeStmtAction and the merged-table
 // emulation in analyzer.go.
 func TestMergeIntoInventory(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=merge_inventory")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -143,6 +144,7 @@ WHEN NOT MATCHED THEN
 // docs/third_party/googlesql-docs/data-manipulation-language.md "TRUNCATE
 // TABLE Inventory" — empties the table without removing it.
 func TestTruncateTable(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=truncate_table")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -184,6 +186,7 @@ func TestTruncateTable(t *testing.T) {
 // "CREATE TABLE AS SELECT" grammar; the expected behaviour is the
 // new table contains the SELECT's rows verbatim.
 func TestCreateTableAsSelect(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=ctas")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -244,6 +247,7 @@ func TestCreateTableAsSelect(t *testing.T) {
 // (lines 130-137 in that file). The expected rows are the subset
 // of customers with id in [min, max].
 func TestTableFunctionCallSimple(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=tvf_simple")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -301,6 +305,7 @@ func TestTableFunctionCallSimple(t *testing.T) {
 // up call must fail. Authoritative source: googlesql DROP FUNCTION
 // grammar (docs/third_party/googlesql-docs/data-definition-language.md).
 func TestDropFunction(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=drop_function")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -346,6 +351,7 @@ func TestDropFunction(t *testing.T) {
 //   - DECLARE x, y, z INT64 DEFAULT 0 → all three read as 0
 //   - SET (a, b, c) = (1+3, 'foo', false) → a=4, b='foo', c=false
 func TestDeclareAndSet(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=declare_set")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -415,6 +421,7 @@ func TestDeclareAndSet(t *testing.T) {
 // DECLARE grammar permits any expression DEFAULT clause, and
 // numeric float literals are the canonical example.
 func TestDeclareFloat(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=declare_float")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -443,6 +450,7 @@ func TestDeclareFloat(t *testing.T) {
 // evaluateScriptVariableExpr — quoted string literals get
 // re-quoted with double-quotes for the rewriter (DQS_DML is on).
 func TestDeclareString(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=declare_string")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -469,6 +477,7 @@ func TestDeclareString(t *testing.T) {
 
 // TestDeclareBool drives the bool branch of evaluateScriptVariableExpr.
 func TestDeclareBool(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=declare_bool")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -496,6 +505,7 @@ func TestDeclareBool(t *testing.T) {
 // ---- from tests/parity/exec_test.go ----
 
 func TestExec(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	ctx := context.Background()
 	ctx = googlesqlite.WithCurrentTime(ctx, now)
@@ -626,6 +636,7 @@ COMMIT TRANSACTION;
 }
 
 func TestNestedStructFieldAccess(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	ctx := context.Background()
 	ctx = googlesqlite.WithCurrentTime(ctx, now)
@@ -696,6 +707,7 @@ CREATE TABLE table (
 }
 
 func TestCreateTempTableParity(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	ctx := context.Background()
 	ctx = googlesqlite.WithCurrentTime(ctx, now)
@@ -719,6 +731,7 @@ func TestCreateTempTableParity(t *testing.T) {
 }
 
 func TestWildcardTable(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
@@ -826,6 +839,7 @@ func TestWildcardTable(t *testing.T) {
 }
 
 func TestTemplatedArgFunc(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
@@ -923,6 +937,7 @@ func TestTemplatedArgFunc(t *testing.T) {
 }
 
 func TestJavaScriptUDF(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {

--- a/functions_test.go
+++ b/functions_test.go
@@ -21,6 +21,7 @@ import (
 // internal/function_javascript.go is the same either way (both go
 // through the bindEvalJavaScript SQL function call).
 func TestJavaScriptUDFPlusOne(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_plusone")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -49,6 +50,7 @@ func TestJavaScriptUDFPlusOne(t *testing.T) {
 
 // TestJavaScriptUDFString exercises STRING return type from a JS UDF.
 func TestJavaScriptUDFString(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_string")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -77,6 +79,7 @@ func TestJavaScriptUDFString(t *testing.T) {
 
 // TestJavaScriptUDFBool exercises BOOL return.
 func TestJavaScriptUDFBool(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_bool")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -119,6 +122,7 @@ func TestJavaScriptUDFBool(t *testing.T) {
 // declares CREATE FUNCTION ... RETURNS INT64 LANGUAGE js as a valid
 // shape; the expected result is the documented arithmetic outcome.
 func TestJavaScriptUDFInt64Return(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_int64")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -151,6 +155,7 @@ func TestJavaScriptUDFInt64Return(t *testing.T) {
 // (user-defined-functions.md "Supported JavaScript UDF data types").
 // The expected return is the literal bytes the JS code emits.
 func TestJavaScriptUDFBytesReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_bytes")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -186,6 +191,7 @@ func TestJavaScriptUDFBytesReturn(t *testing.T) {
 // (data-types.md "Date type") — "YYYY-MM-DD" parses cleanly to a
 // DateValue.
 func TestJavaScriptUDFDateReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_date")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -214,6 +220,7 @@ func TestJavaScriptUDFDateReturn(t *testing.T) {
 // TestJavaScriptUDFTimeReturn exercises the TIME branch of
 // castJavaScriptValue. GoogleSQL TIME literals are "HH:MM:SS".
 func TestJavaScriptUDFTimeReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_time")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -242,6 +249,7 @@ func TestJavaScriptUDFTimeReturn(t *testing.T) {
 // TestJavaScriptUDFDatetimeReturn exercises the DATETIME branch of
 // castJavaScriptValue. GoogleSQL DATETIME literal: "YYYY-MM-DD HH:MM:SS".
 func TestJavaScriptUDFDatetimeReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_datetime")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -271,6 +279,7 @@ func TestJavaScriptUDFDatetimeReturn(t *testing.T) {
 // castJavaScriptValue. GoogleSQL TIMESTAMP literal format with a UTC
 // offset is parsed through value.ParseTimestamp.
 func TestJavaScriptUDFTimestampReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_ts")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -299,6 +308,7 @@ func TestJavaScriptUDFTimestampReturn(t *testing.T) {
 // TestJavaScriptUDFNumericReturn exercises the NUMERIC branch of
 // castJavaScriptValue (sets value.NumericValue from v.ToNumber()).
 func TestJavaScriptUDFNumericReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_numeric")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -330,6 +340,7 @@ func TestJavaScriptUDFNumericReturn(t *testing.T) {
 // castJavaScriptValue, which routes identically to NUMERIC through
 // big.Rat.SetString.
 func TestJavaScriptUDFBignumericReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_bignumeric")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -358,6 +369,7 @@ func TestJavaScriptUDFBignumericReturn(t *testing.T) {
 // TestJavaScriptUDFJsonReturn exercises the JSON branch of
 // castJavaScriptValue (wraps v.ToString() in a JsonValue).
 func TestJavaScriptUDFJsonReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_json")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -392,6 +404,7 @@ func TestJavaScriptUDFJsonReturn(t *testing.T) {
 // castJavaScriptValue. Source: user-defined-functions.md JS UDF type
 // table — BOOL is supported and bridges through v.ToBoolean().
 func TestJavaScriptUDFBoolReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_bool")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -428,6 +441,7 @@ func TestJavaScriptUDFBoolReturn(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-types.md "Interval type"
 // — GoogleSQL accepts ISO-8601 interval strings.
 func TestJavaScriptUDFIntervalReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_interval")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -467,6 +481,7 @@ func TestJavaScriptUDFIntervalReturn(t *testing.T) {
 // "Supported JavaScript UDF data types" — ARRAY is supported with
 // JS arrays as the input/output representation.
 func TestJavaScriptUDFArrayReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_array")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -515,6 +530,7 @@ func TestJavaScriptUDFArrayReturn(t *testing.T) {
 // JS body returns a plain object {a: 1, b: "hi"}, mapped to the
 // declared field names.
 func TestJavaScriptUDFStructReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_struct")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -549,6 +565,7 @@ func TestJavaScriptUDFStructReturn(t *testing.T) {
 // tested in js_udf_test.go but the explicit RETURNS STRING path is
 // distinct from the value-from-go-value path.
 func TestJavaScriptUDFStringExplicit(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_string_explicit")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -576,6 +593,7 @@ func TestJavaScriptUDFStringExplicit(t *testing.T) {
 
 // TestJavaScriptUDFFloatReturn drives the FLOAT64/DOUBLE branch.
 func TestJavaScriptUDFFloatReturn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_float")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -604,6 +622,7 @@ func TestJavaScriptUDFFloatReturn(t *testing.T) {
 // TestJavaScriptUDFNullArg drives the NULL-handling fast path:
 // castJavaScriptValue with v==nil returns (nil, nil).
 func TestJavaScriptUDFNullArg(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=js_udf_null")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -644,6 +663,7 @@ func TestJavaScriptUDFNullArg(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/conditional_expressions.md
 // "IFERROR" — when the first arg raises, returns the second arg.
 func TestIferrorWithErrorAndInt(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=iferror_int")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -663,6 +683,7 @@ func TestIferrorWithErrorAndInt(t *testing.T) {
 // TestIferrorWithErrorAndString drives the IFERROR pattern for a
 // string second argument.
 func TestIferrorWithErrorAndString(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=iferror_string")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -682,6 +703,7 @@ func TestIferrorWithErrorAndString(t *testing.T) {
 // TestIferrorNoError drives the no-error branch — first arg evaluates
 // successfully, so the second arg is unused.
 func TestIferrorNoError(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=iferror_no_error")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -701,6 +723,7 @@ func TestIferrorNoError(t *testing.T) {
 // TestIserror drives ISERROR — returns TRUE if the inner expression
 // raises, FALSE otherwise.
 func TestIserror(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=iserror")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -725,6 +748,7 @@ func TestIserror(t *testing.T) {
 
 // TestNullIferror drives NULLIFERROR — returns NULL if the inner raises.
 func TestNullIferror(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=nulliferror")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -751,6 +775,7 @@ func TestNullIferror(t *testing.T) {
 // "IFERROR" — the rewriter infers the return type from the second arg
 // when the first arg is ERROR(...).
 func TestIferrorTypePropagationVariants(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=iferror_types")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -823,6 +848,7 @@ func TestIferrorTypePropagationVariants(t *testing.T) {
 // TestIferrorPropagationNested drives the multi-level iferror rewrite.
 // IFERROR nesting hits the recursive split / propagation path.
 func TestIferrorPropagationNested(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=iferror_nested")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -864,6 +890,7 @@ func TestIferrorPropagationNested(t *testing.T) {
 // that in an ErrorGroup, and reading .Error() triggers the previously
 // uncovered string-join path.
 func TestErrorGroupErrorPath(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=error_group")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/goccy/googlesqlite"
 )
@@ -16,6 +17,13 @@ import (
 // programmatic configuration API. CI sets these variables already, in
 // which case the existing values are kept.
 func TestMain(m *testing.M) {
+	// Pin the process timezone to UTC for the whole suite. Timestamp
+	// tests need a deterministic zone; fixing it once here (instead of
+	// per-test t.Setenv/os.Setenv) keeps those tests free of process-
+	// global mutation so they can run with t.Parallel().
+	os.Setenv("TZ", "UTC")
+	time.Local = time.UTC
+
 	if os.Getenv(googlesqlite.EnvWasmCompilationMode) == "" {
 		os.Setenv(googlesqlite.EnvWasmCompilationMode, string(googlesqlite.WasmCompilationModeCompiler))
 		if os.Getenv(googlesqlite.EnvWasmCacheDir) == "" {

--- a/query_test.go
+++ b/query_test.go
@@ -51,6 +51,7 @@ func rowDump(t *testing.T, rows *sql.Rows) [][]any {
 // Inputs and expected outputs come from
 // docs/third_party/googlesql-docs/query-syntax.md (set-operations section).
 func TestSetOperationsUnionIntersectExcept(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=setops")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -143,6 +144,7 @@ func TestSetOperationsUnionIntersectExcept(t *testing.T) {
 // 2430). Expected rows are sourced from the visual tables in those
 // examples.
 func TestJoinVariants(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=joins")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -223,6 +225,7 @@ func TestJoinVariants(t *testing.T) {
 // expected outputs come from query-syntax.md SELECT * EXCEPT / SELECT
 // * REPLACE examples.
 func TestSelectExceptAndReplace(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=select_except")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -261,6 +264,7 @@ func TestSelectExceptAndReplace(t *testing.T) {
 // This exercises the parameter-encoding pipeline in encoder.go and
 // the StmtExecContext path's args reshape.
 func TestParameterBindingTypes(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=param_types")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -340,6 +344,7 @@ func TestParameterBindingTypes(t *testing.T) {
 // formatter via WITH RECURSIVE. The example is from
 // docs/third_party/googlesql-docs/query-syntax.md WITH clause section.
 func TestWithRecursiveSelfReferential(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=with_recursive")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -386,6 +391,7 @@ func TestWithRecursiveSelfReferential(t *testing.T) {
 // operators" + query-syntax.md). The values are simple integers so
 // the assertions stay tight.
 func TestExistsAndInSubquery(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=subquery_exprs")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -425,6 +431,7 @@ func TestExistsAndInSubquery(t *testing.T) {
 // at docs/third_party/googlesql-docs/parameters.md (ARRAY parameter
 // expansion as `(?, ?, ...)`).
 func TestArrayUnnestRoundtrip(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=array_unnest")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -463,6 +470,7 @@ func TestArrayUnnestRoundtrip(t *testing.T) {
 // frame specification (ROWS BETWEEN / RANGE BETWEEN / window_spec
 // shorthand).
 func TestWindowVariousFrames(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=window_frames_extra")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -557,6 +565,7 @@ func TestWindowVariousFrames(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "SELECT *
 // modifiers".
 func TestSelectStarReplace(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=select_star_replace")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -599,6 +608,7 @@ func TestSelectStarReplace(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md JOIN
 // operations (INNER, LEFT, RIGHT, FULL, CROSS).
 func TestJoinVariantsExtra(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=join_variants")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -648,6 +658,7 @@ func TestJoinVariantsExtra(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "UNNEST
 // operator with array_expression and WITH OFFSET".
 func TestUnnestWithOffset(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=unnest_offset")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -686,6 +697,7 @@ func TestUnnestWithOffset(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "Recursive CTEs"
 // — example builds an integer ladder via UNION ALL.
 func TestRecursiveCTE(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=recursive_cte")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -722,6 +734,7 @@ func TestRecursiveCTE(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "LIMIT clause"
 // + "OFFSET clause".
 func TestLimitOffset(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=limit_offset")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -754,6 +767,7 @@ func TestLimitOffset(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "ORDER BY
 // clause" — NULLS FIRST / NULLS LAST options.
 func TestOrderByDescAndNullsFirst(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=order_by_nulls")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -789,6 +803,7 @@ func TestOrderByDescAndNullsFirst(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "GROUP BY
 // clause" + "SELECT DISTINCT modifier".
 func TestSelectDistinctAndGroupBy(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=distinct_groupby")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -837,6 +852,7 @@ func TestSelectDistinctAndGroupBy(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/conditional_expressions.md
 // "CASE expr WHEN".
 func TestCaseExpression(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=case_expr")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -861,6 +877,7 @@ func TestCaseExpression(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-types.md "NUMERIC type"
 // — arithmetic uses exact precision; div-by-zero is an analyzer error.
 func TestNumericArithmetic(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=numeric_arith")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -895,6 +912,7 @@ func TestNumericArithmetic(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/dml-syntax.md "UPDATE
 // statement".
 func TestUpdateSetWhere(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=update_set_where")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -940,6 +958,7 @@ func TestUpdateSetWhere(t *testing.T) {
 // partition: each row's partition has only one boolean so the
 // LOGICAL_OR matches the input directly.
 func TestWindowDistinctEmulationPath(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=window_emulation")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -989,6 +1008,7 @@ func TestWindowDistinctEmulationPath(t *testing.T) {
 // hits the native sliding-frame path which still emits ORDER BY
 // markers and frame bounds.
 func TestWindowOrderedFrame(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=window_ordered_frame")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1044,6 +1064,7 @@ func TestWindowOrderedFrame(t *testing.T) {
 //
 // Expected output: a sorted array of the first two elements.
 func TestArrayAggLimitOrderBy(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=array_agg_limit_order_by")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1075,6 +1096,7 @@ func TestArrayAggLimitOrderBy(t *testing.T) {
 // TestArrayAggOrderByDesc drives bindOrderBy with the descending flag.
 // Source: aggregate_functions.md ARRAY_AGG ORDER BY DESC grammar.
 func TestArrayAggOrderByDesc(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=array_agg_order_by_desc")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1106,6 +1128,7 @@ func TestArrayAggOrderByDesc(t *testing.T) {
 // "STRING_AGG" — supports the same ORDER BY / LIMIT modifiers as
 // ARRAY_AGG.
 func TestStringAggOrderByLimit(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=string_agg_order_by_limit")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1142,6 +1165,7 @@ func TestStringAggOrderByLimit(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "TABLESAMPLE"
 // section.
 func TestTableSample(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=table_sample")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1192,6 +1216,7 @@ func TestTableSample(t *testing.T) {
 // clause" — fires after window functions, allowing predicates over
 // window-derived columns.
 func TestQualifyClause(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=qualify_clause")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1232,6 +1257,7 @@ func TestQualifyClause(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "SELECT clause"
 // expressions create computed columns.
 func TestComputedColumnsInProject(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=computed_columns")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1278,6 +1304,7 @@ func TestComputedColumnsInProject(t *testing.T) {
 // for STRUCT" — `struct_value.field_name` lowers to a GetStructField
 // node.
 func TestGetStructField(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=get_struct_field")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1311,6 +1338,7 @@ func TestGetStructField(t *testing.T) {
 // the navigation_functions.md "LAG" / "LEAD" examples. Expected
 // values come straight from the LAG / LEAD definitions.
 func TestLagLeadFirstLast(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=lag_lead")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1380,6 +1408,7 @@ func TestLagLeadFirstLast(t *testing.T) {
 // "ROWS vs. RANGE" — RANGE bounds are based on value rather than row
 // position.
 func TestRangeFrame(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=range_frame")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1430,6 +1459,7 @@ func TestRangeFrame(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/numbering_functions.md
 // "PERCENT_RANK", "CUME_DIST", "NTILE".
 func TestPercentRankCumeDistNtile(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=numbering_funcs")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1480,6 +1510,7 @@ func TestPercentRankCumeDistNtile(t *testing.T) {
 // rows by GROUPING SETS section, lines 1170-1190 of that file).
 // Exercises GroupingSetNode + ColumnHolderNode in the formatter.
 func TestGroupingSets(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=grouping_sets")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1532,6 +1563,7 @@ func TestGroupingSets(t *testing.T) {
 //
 // Source: query-syntax.md ROLLUP and CUBE sections.
 func TestRollupAndCube(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=rollup_cube")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1590,6 +1622,7 @@ func TestRollupAndCube(t *testing.T) {
 // Source: docs/third_party/googlesql-docs/procedural-language.md
 // "@@time_zone" (system variable section).
 func TestSystemVariableTimeZone(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=sysvar_tz")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1621,6 +1654,7 @@ func TestSystemVariableTimeZone(t *testing.T) {
 // "ARRAY_TRANSFORM" reference. The expected output is the input
 // array with the lambda applied per element.
 func TestArrayTransformLambda(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=lambda_array_transform")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1657,6 +1691,7 @@ func TestArrayTransformLambda(t *testing.T) {
 // query-syntax.md PIVOT / UNPIVOT sections; the table shapes are
 // taken from the docs' examples.
 func TestPivotAndUnpivot(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=pivot_unpivot")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1704,6 +1739,7 @@ func TestPivotAndUnpivot(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "PIVOT" and
 // "UNPIVOT" sections.
 func TestPivotAndUnpivotExtra(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=pivot_unpivot")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1759,6 +1795,7 @@ func TestPivotAndUnpivotExtra(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/query-syntax.md "UNNEST" with
 // STRUCT-typed elements.
 func TestArrayUnnestStruct(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=unnest_struct")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1797,6 +1834,7 @@ func TestArrayUnnestStruct(t *testing.T) {
 // TestArrayConcatBetweenLiterals drives FunctionCallNode for
 // ARRAY_CONCAT — uses VARIADIC + non-trivial dispatch.
 func TestArrayConcatBetweenLiterals(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=array_concat")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1818,6 +1856,7 @@ func TestArrayConcatBetweenLiterals(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-manipulation-language.md
 // "INSERT ... SELECT".
 func TestInsertWithSelect(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=insert_select")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1846,6 +1885,7 @@ func TestInsertWithSelect(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-manipulation-language.md
 // "DELETE".
 func TestDeleteWithSubquery(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=delete_subq")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1876,6 +1916,7 @@ func TestDeleteWithSubquery(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/expressions.md "Subqueries"
 // section.
 func TestSubqueryExpr(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=subquery_expr")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1935,6 +1976,7 @@ func TestSubqueryExpr(t *testing.T) {
 // TestSystemVariableSet drives SystemVariableNode read after a SET.
 // Reference: docs/third_party/googlesql-docs/system-variables.md.
 func TestSystemVariableSet(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=sysvar_set")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1966,6 +2008,7 @@ func TestSystemVariableSet(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/aggregate_functions.md
 // "STRING_AGG" with ORDER BY.
 func TestAggregateModifiers(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=agg_modifiers")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1993,11 +2036,13 @@ func TestAggregateModifiers(t *testing.T) {
 // current build — the underlying mechanism is exercised by spectest's
 // proto fixtures.
 func TestFilterFieldsProto(t *testing.T) {
+	t.Parallel()
 	t.Skip("FILTER_FIELDS requires proto registration plumbing; covered by spectest")
 }
 
 // TestAnonymizedDPAggregate skipped — DP aggregates require feature flags.
 func TestAnonymizedDPAggregate(t *testing.T) {
+	t.Parallel()
 	t.Skip("DP aggregates require feature flags; covered by spectest")
 }
 
@@ -2016,6 +2061,7 @@ func TestAnonymizedDPAggregate(t *testing.T) {
 // catalog-internal order, every row gets the _TABLE_SUFFIX synthetic
 // column.
 func TestWildcardTableScan(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=wildcard_scan")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2084,6 +2130,7 @@ func TestWildcardTableScan(t *testing.T) {
 // docs/specs/googlesql/information_schema/tables.md (and its
 // testdata YAML). The view returns one row per registered table.
 func TestInformationSchemaTables(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=info_tables")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2138,6 +2185,7 @@ func TestInformationSchemaTables(t *testing.T) {
 // which surfaces one row per column with its name and data type.
 // Source: docs/specs/googlesql/information_schema/columns.md.
 func TestInformationSchemaColumns(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=info_columns")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2199,6 +2247,7 @@ func TestInformationSchemaColumns(t *testing.T) {
 // CREATE TABLE in a previously-unseen dataset adds a schema entry.
 // Source: docs/specs/googlesql/information_schema/schemata.md.
 func TestInformationSchemaSchemata(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=info_schemata")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2255,6 +2304,7 @@ func TestInformationSchemaSchemata(t *testing.T) {
 // "INFORMATION_SCHEMA.COLUMNS" — ordinal_position is the
 // per-table column index (1-based).
 func TestInformationSchemaColumnsOrdinalPosition(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=info_columns_ordinal")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2313,6 +2363,7 @@ func TestInformationSchemaColumnsOrdinalPosition(t *testing.T) {
 // column lists the canonical type name); ARRAY columns are formatted
 // "ARRAY<...>" with the inner type in brackets.
 func TestInformationSchemaColumnsArrayType(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=info_columns_array")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2348,6 +2399,7 @@ func TestInformationSchemaColumnsArrayType(t *testing.T) {
 // TestInformationSchemaColumnsStructType drives the STRUCT branch of
 // infoSchemaDataType.
 func TestInformationSchemaColumnsStructType(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=info_columns_struct")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2395,6 +2447,7 @@ func TestInformationSchemaColumnsStructType(t *testing.T) {
 //	FROM UNNEST(["apple", "pear", "banana", "pear"]) AS fruit;
 //	-> "pear & pear & apple & banana"
 func TestStringAggOrderBy(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=string_agg_order_by")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2425,6 +2478,7 @@ func TestStringAggOrderBy(t *testing.T) {
 //	FROM UNNEST(["apple", "pear", "banana", "pear"]) AS fruit;
 //	-> "apple & pear"
 func TestStringAggLimit(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=string_agg_limit")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2457,6 +2511,7 @@ func TestStringAggLimit(t *testing.T) {
 //	FROM UNNEST(["apple", "pear", "banana", "pear"]) AS fruit;
 //	-> "pear & banana"
 func TestStringAggDistinctOrderByLimit(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=string_agg_distinct_order_limit")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2482,6 +2537,7 @@ func TestStringAggDistinctOrderByLimit(t *testing.T) {
 // Authoritative source: docs/third_party/googlesql-docs/aggregate_functions.md
 // "ARRAY_AGG" section ARRAY_AGG(x ORDER BY x LIMIT N) example.
 func TestArrayAggOrderByLimit(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=array_agg_order_by_limit")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -2509,7 +2565,7 @@ func TestArrayAggOrderByLimit(t *testing.T) {
 // ---- from tests/parity/query_test.go ----
 
 func TestQuery(t *testing.T) {
-	t.Setenv("TZ", "UTC")
+	t.Parallel()
 	now := time.Now()
 	ctx := context.Background()
 	ctx = googlesqlite.WithCurrentTime(ctx, now)

--- a/regression_test.go
+++ b/regression_test.go
@@ -16,6 +16,7 @@ import (
 // America/Los_Angeles, so EXTRACT(HOUR FROM TIMESTAMP '2024-01-01 12:00:00')
 // returned 20 instead of 12. This regression test pins the fix.
 func TestRegression_DefaultTimezoneIsUTC(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -37,6 +38,7 @@ func TestRegression_DefaultTimezoneIsUTC(t *testing.T) {
 //
 // Regression: BigQuery documents INTEGER and INT as aliases for INT64.
 func TestRegression_IntegerTypeAlias(t *testing.T) {
+	t.Parallel()
 	for _, alias := range []string{"INTEGER", "INT", "SMALLINT", "BIGINT", "TINYINT"} {
 		t.Run(alias, func(t *testing.T) {
 			db, err := sql.Open("googlesqlite", "file:alias_"+alias+"?mode=memory&cache=private")
@@ -63,6 +65,7 @@ func TestRegression_IntegerTypeAlias(t *testing.T) {
 
 // TestA1_ContainsSubstr
 func TestA1_ContainsSubstr(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	for _, tc := range []struct {
@@ -97,6 +100,7 @@ func TestA1_ContainsSubstr(t *testing.T) {
 
 // TestA2_EditDistance — zlite#212
 func TestA2_EditDistance(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	for _, tc := range []struct {
@@ -122,6 +126,7 @@ func TestA2_EditDistance(t *testing.T) {
 
 // TestA3_MaxByMinBy — bqe#388 / bqe#356
 func TestA3_MaxByMinBy(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	row := db.QueryRowContext(context.Background(), `
@@ -146,6 +151,7 @@ FROM UNNEST([
 
 // TestA4_Lax — bqe#243
 func TestA4_Lax(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	for _, tc := range []struct {
@@ -222,6 +228,7 @@ func TestA4_Lax(t *testing.T) {
 
 // TestA5_LogicalOrAndWindow — zlite#200
 func TestA5_LogicalOrAndWindow(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	rows, err := db.QueryContext(context.Background(), `
@@ -273,6 +280,7 @@ ORDER BY i
 // `EXPORT DATA OPTIONS(...) AS SELECT ...` as a query and returns the
 // inner SELECT's rows, leaving the actual export to consumer code.
 func TestW_ExportData(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -302,6 +310,7 @@ UNION ALL SELECT 2, 'bob'`)
 
 // TestW_GeographyExtra covers the G1 ST_* additions.
 func TestW_GeographyExtra(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -396,6 +405,7 @@ func TestW_GeographyExtra(t *testing.T) {
 // CREATE TABLE FUNCTION statement is accepted as a DDL no-op. The
 // call site (ResolvedTvfscan) is the follow-up — see TestW_TVF_Call.
 func TestW_TVF_DDL(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -412,6 +422,7 @@ func TestW_TVF_DDL(t *testing.T) {
 // inlines the body with arg substitution. Covers single-arg, multi-
 // arg, and multi-column-output variations.
 func TestW_TVF_Call(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -456,6 +467,7 @@ func TestW_TVF_Call(t *testing.T) {
 //
 // Origin: bqe#344.
 func TestW_DeclareSetScript(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -510,6 +522,7 @@ func TestW_DeclareSetScript(t *testing.T) {
 //
 // Origin: bqe#317.
 func TestW_PartitionTimePseudoColumn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -547,6 +560,7 @@ func TestW_PartitionTimePseudoColumn(t *testing.T) {
 //
 // Origin: bqe#299, bqe#128.
 func TestW_UpdateStructFieldRewrite(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -609,6 +623,7 @@ func TestW_UpdateStructFieldRewrite(t *testing.T) {
 //
 // Origin: bqe#211, bqe#73.
 func TestW_DefaultClauseSubstitution(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -673,6 +688,7 @@ func TestW_DefaultClauseSubstitution(t *testing.T) {
 //
 // Origin: B1 driver-side partial in upstream-asks.md.
 func TestW_GeographyNonPoint(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -729,6 +745,7 @@ func TestW_GeographyNonPoint(t *testing.T) {
 // equality through the value-aware collation that already
 // understands StructValue positionally.
 func TestW_StructInSubqueryAnonymousFields(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -783,6 +800,7 @@ func TestW_StructInSubqueryAnonymousFields(t *testing.T) {
 //
 // Origin: bqe#48.
 func TestW_InformationSchema(t *testing.T) {
+	t.Parallel()
 	tmp, err := os.CreateTemp("", "info-*.db")
 	if err != nil {
 		t.Fatal(err)
@@ -905,6 +923,7 @@ func TestW_InformationSchema(t *testing.T) {
 // toggle (no observable behavioural difference; the toggle gates
 // the hint emission).
 func TestW_CteMaterializeMultiRef(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -970,6 +989,7 @@ SELECT SUM(n) FROM seq`)
 // of the predecessor's correlated-subquery emulation. F11 hardens
 // this so all built-in window aggregators dispatch natively.
 func TestW_NativeWindowAggregators(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1089,6 +1109,7 @@ func TestW_NativeWindowAggregators(t *testing.T) {
 // rewritten to `INT64`, producing duplicate-name SQL and downstream
 // "no such column" errors.
 func TestW_TypeAliasNotInColumnName(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1127,6 +1148,7 @@ func TestW_TypeAliasNotInColumnName(t *testing.T) {
 //
 // Origin: bqe#318.
 func TestW_BqutilNamepathAlias(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1160,6 +1182,7 @@ func TestW_BqutilNamepathAlias(t *testing.T) {
 //
 // Origin: bqe#147.
 func TestW_SystemVariableAssignAndRead(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1204,6 +1227,7 @@ func TestW_SystemVariableAssignAndRead(t *testing.T) {
 //
 // Origin: upstream feature.
 func TestW_JsonMutators(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1262,6 +1286,7 @@ func TestW_JsonMutators(t *testing.T) {
 //
 // Origin: bqe#357.
 func TestW_JsonValueNonLiteralPath(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1290,6 +1315,7 @@ func TestW_JsonValueNonLiteralPath(t *testing.T) {
 //
 // Origin: upstream regression.
 func TestW_RangeConstructor(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1351,6 +1377,7 @@ SELECT
 //
 // Origin: predecessor regression.
 func TestW_WithRecursive(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1388,6 +1415,7 @@ SELECT n FROM t ORDER BY n`)
 
 // TestRegression_DDLPartitionByAccepted: bqe#152
 func TestRegression_DDLPartitionByAccepted(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f5_152?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1398,6 +1426,7 @@ func TestRegression_DDLPartitionByAccepted(t *testing.T) {
 
 // TestRegression_DDLClusterByAccepted: bqe#373
 func TestRegression_DDLClusterByAccepted(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f5_373?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1408,6 +1437,7 @@ func TestRegression_DDLClusterByAccepted(t *testing.T) {
 
 // TestRegression_DDLColumnOptionsAccepted: bqe#212
 func TestRegression_DDLColumnOptionsAccepted(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f5_212?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1422,11 +1452,13 @@ func TestRegression_DDLColumnOptionsAccepted(t *testing.T) {
 // catalog-side metadata + an INSERT-time expression evaluator.
 // Tracked as a design question for the user, not a one-shot bug fix.
 func TestRegression_DDLDefaultClauseInsertOmitted(t *testing.T) {
+	t.Parallel()
 	t.Skip("DEFAULT clause persistence is a design change; deferred for user discussion")
 }
 
 // TestRegression_DDLNotNull: bqe#210
 func TestRegression_DDLNotNull(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f5_210?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1442,6 +1474,7 @@ func TestRegression_DDLNotNull(t *testing.T) {
 
 // TestRegression_CTASWithColumnList: bqe#306
 func TestRegression_CTASWithColumnList(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f5_306?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1454,6 +1487,7 @@ func TestRegression_CTASWithColumnList(t *testing.T) {
 
 // TestRegression_UpdateFromSelect: bqe#310
 func TestRegression_UpdateFromSelect(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f6_310?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1478,6 +1512,7 @@ func TestRegression_UpdateFromSelect(t *testing.T) {
 
 // TestRegression_ReservedFieldName_End: bqe#402
 func TestRegression_ReservedFieldName_End(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f7_402?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1488,6 +1523,7 @@ func TestRegression_ReservedFieldName_End(t *testing.T) {
 
 // TestRegression_TruncateTable: bqe#378
 func TestRegression_TruncateTable(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f7_378?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1502,6 +1538,7 @@ func TestRegression_TruncateTable(t *testing.T) {
 
 // TestRegression_LikeNullLHS: zlite#185
 func TestRegression_LikeNullLHS(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	row := db.QueryRowContext(context.Background(),
@@ -1520,6 +1557,7 @@ func TestRegression_LikeNullLHS(t *testing.T) {
 
 // TestRegression_TableSuffixLongestPrefix: bqe#272
 func TestRegression_TableSuffixLongestPrefix(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", "file:f9_272?mode=memory&cache=private")
 	db.SetMaxOpenConns(1)
 	defer db.Close()
@@ -1559,6 +1597,7 @@ func TestRegression_TableSuffixLongestPrefix(t *testing.T) {
 
 // TestRegression_TimestampFloatToInt: bqe#390
 func TestRegression_TimestampFloatToInt(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	row := db.QueryRowContext(context.Background(),
@@ -1574,6 +1613,7 @@ func TestRegression_TimestampFloatToInt(t *testing.T) {
 
 // TestRegression_DatetimeAsStringSpaceSeparator: bqe#175
 func TestRegression_DatetimeAsStringSpaceSeparator(t *testing.T) {
+	t.Parallel()
 	db, _ := sql.Open("googlesqlite", ":memory:")
 	defer db.Close()
 	row := db.QueryRowContext(context.Background(),
@@ -1591,6 +1631,7 @@ func TestRegression_DatetimeAsStringSpaceSeparator(t *testing.T) {
 // JSON_EXTRACT_SCALAR extract the field at the path, not the entire
 // JSON document.
 func TestRegression_JsonQueryExtractsField(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1614,6 +1655,7 @@ func TestRegression_JsonQueryExtractsField(t *testing.T) {
 // TestRegression_JsonExtractQuotedSegment asserts that JSON_EXTRACT
 // accepts a double-quoted path segment containing dots.
 func TestRegression_JsonExtractQuotedSegment(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1634,6 +1676,7 @@ func TestRegression_JsonExtractQuotedSegment(t *testing.T) {
 // TestRegression_JsonValueOnTypedJsonColumn asserts that JSON_VALUE
 // works against a column of type JSON populated via PARSE_JSON.
 func TestRegression_JsonValueOnTypedJsonColumn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", "file:json_typed?mode=memory&cache=private")
 	if err != nil {
 		t.Fatal(err)
@@ -1661,6 +1704,7 @@ func TestRegression_JsonValueOnTypedJsonColumn(t *testing.T) {
 // TestRegression_PercentileContValues asserts that PERCENTILE_CONT
 // over [20, 30, 40] returns the documented BigQuery values.
 func TestRegression_PercentileContValues(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1695,6 +1739,7 @@ FROM cte LIMIT 1`)
 // TestRegression_ArrayLengthCompareInJoin asserts ARRAY_LENGTH on a
 // nullable JOIN result does not panic.
 func TestRegression_ArrayLengthCompareInJoin(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1737,6 +1782,7 @@ ORDER BY t1.idx`)
 // Regression: the predecessor panicked in WINDOW_DENSE_RANK.Done with a
 // nil pointer dereference.
 func TestRegression_RankOverNullColumn(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1773,6 +1819,7 @@ FROM t`)
 //
 // Origin: predecessor regression.
 func TestRegression_WindowNullPartition(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1813,6 +1860,7 @@ ORDER BY finish_time
 // Origin: the previous driver returned
 // "mismatch rowid 1 != 2" because the rewriter assumed an ORDER BY.
 func TestRegression_CountStarOverEmpty(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1854,6 +1902,7 @@ ORDER BY item
 // TestRegression_DateTruncIsoweek asserts that DATE_TRUNC(... ISOWEEK)
 // returns the Monday of the ISO week containing the given date.
 func TestRegression_DateTruncIsoweek(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		desc, query, want string
 	}{
@@ -1891,6 +1940,7 @@ func TestRegression_DateTruncIsoweek(t *testing.T) {
 // Regression: SQLite was constant-folding the call because the function
 // was registered with the deterministic flag.
 func TestRegression_GenerateUuidPerRow(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1921,6 +1971,7 @@ SELECT GENERATE_UUID() FROM UNNEST([1, 2, 3, 4, 5]) AS x`)
 // Origin: `PARSE_DATE("%D", "99/01/24")`
 // returned "2032-03-01" by overflowing the month into the year part.
 func TestRegression_ParseDateOverflow(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -1941,6 +1992,7 @@ func TestRegression_ParseDateOverflow(t *testing.T) {
 //
 // Origin: predecessor regression.
 func TestRegression_TrimUnicodeWhitespace(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		desc, query, want string
 	}{
@@ -1972,6 +2024,7 @@ func TestRegression_TrimUnicodeWhitespace(t *testing.T) {
 //
 // Origin: predecessor regression.
 func TestRegression_WindowOrderByNulls(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -2029,6 +2082,7 @@ ORDER BY 3
 //
 // Origin: predecessor regression.
 func TestRegression_FormatDate_PercentU(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		desc string
 		date string
@@ -2065,6 +2119,7 @@ func TestRegression_FormatDate_PercentU(t *testing.T) {
 // Origin: implementation called gonum's
 // `stat.Covariance` which returns sample covariance.
 func TestRegression_CovarPop(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -2102,6 +2157,7 @@ SELECT COVAR_POP(y, x) FROM UNNEST([
 // sub-day fractional difference up to 1, returning 1 for a 30-minute
 // gap on the same day.
 func TestRegression_DatetimeDiffSameDay(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		desc  string
 		query string
@@ -2144,6 +2200,7 @@ func TestRegression_DatetimeDiffSameDay(t *testing.T) {
 // TestRegression_InUnnestArrayParam asserts that an array passed via a
 // named parameter survives `SELECT * FROM UNNEST(@arr)` analysis.
 func TestRegression_InUnnestArrayParam(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)

--- a/types_test.go
+++ b/types_test.go
@@ -3,7 +3,6 @@ package googlesqlite_test
 import (
 	"context"
 	"database/sql"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -22,6 +21,7 @@ import (
 // Reference: database/sql doc for ColumnType.DatabaseTypeName plus the
 // public googlesqlite.UnmarshalDatabaseTypeName API surface.
 func TestColumnTypeDatabaseTypeName(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=column_type_dtn")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -74,6 +74,7 @@ func TestColumnTypeDatabaseTypeName(t *testing.T) {
 // parameters" — binding a Go type to `?` should select the
 // corresponding GoogleSQL primitive.
 func TestParameterTypeInference(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=param_type_inference")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -154,6 +155,7 @@ func TestParameterTypeInference(t *testing.T) {
 //
 // Reference: docs/third_party/googlesql-docs/parameters.md "Named parameters".
 func TestNamedParameterBinding(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=named_param")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -184,6 +186,7 @@ func TestNamedParameterBinding(t *testing.T) {
 //
 // Expected: UNNEST returns the elements one per row.
 func TestParameterAsArray(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=param_array")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -239,6 +242,7 @@ func TestParameterAsArray(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/parameters.md — every Go
 // primitive maps to a corresponding GoogleSQL type.
 func TestParameterTypeInferenceMore(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=param_more_types")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -327,6 +331,7 @@ func TestParameterTypeInferenceMore(t *testing.T) {
 //
 // Reference: docs/third_party/googlesql-docs/parameters.md "ARRAY parameter".
 func TestArrayParameterVariants(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=param_array_variants")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -396,6 +401,7 @@ func TestArrayParameterVariants(t *testing.T) {
 //
 // Reference: docs/third_party/googlesql-docs/data-types.md "TIMESTAMP type".
 func TestTimestampParameter(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=param_timestamp")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -431,6 +437,7 @@ func TestTimestampParameter(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-types.md "DATE" — Go's
 // time.Time round-trips through DATE columns.
 func TestDateParamRoundTrip(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=date_param")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -459,6 +466,7 @@ func TestDateParamRoundTrip(t *testing.T) {
 // path through ParameterNode.FormatSQL when paramCollectorFromContext
 // is active.
 func TestExecWithMultiplePositionalParams(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=positional_params")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -488,6 +496,7 @@ func TestExecWithMultiplePositionalParams(t *testing.T) {
 // googleSQLTypeForEncodedString TimestampValue / DatetimeValue branches
 // when binding time.Time against typed columns.
 func TestDatetimeAndTimestampValueParams(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=dt_ts_param")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -526,6 +535,7 @@ func TestDatetimeAndTimestampValueParams(t *testing.T) {
 // Reference: database/sql Scan rules — pointers to integer types
 // receive a conversion from the column's int64 source.
 func TestScanIntoEveryIntSize(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=scan_int_sizes")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -637,6 +647,7 @@ func TestScanIntoEveryIntSize(t *testing.T) {
 // TestScanIntoFloatSizes drives assignValue's float branches by
 // scanning a FLOAT64 column into both float32 and float64 destinations.
 func TestScanIntoFloatSizes(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=scan_float_sizes")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -677,6 +688,7 @@ func TestScanIntoFloatSizes(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-types.md "NUMERIC"
 // section — round-trip of canonical decimal string.
 func TestScanStringAffinityTypes(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=scan_affinity_types")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -714,6 +726,7 @@ func TestScanStringAffinityTypes(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-types.md "RANGE" and
 // "INTERVAL" sections — canonical string form is the round-trip.
 func TestScanRangeInterval(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=range_interval_scan")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -760,6 +773,7 @@ func TestScanRangeInterval(t *testing.T) {
 //
 // Reference: docs/third_party/googlesql-docs/data-types.md "JSON" type.
 func TestScanJSONIntoTypes(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=scan_json")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -788,6 +802,7 @@ func TestScanJSONIntoTypes(t *testing.T) {
 //
 // Reference: docs/third_party/googlesql-docs/data-types.md "GEOGRAPHY".
 func TestScanGeographyIntoString(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=scan_geo")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -811,6 +826,7 @@ func TestScanGeographyIntoString(t *testing.T) {
 // Reference: database/sql sql.ColumnType — DatabaseTypeName returns
 // the JSON-encoded type spec stored on each column.
 func TestColumnTypeDatabaseTypeNameMore(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=column_type_db_name")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -845,6 +861,7 @@ func TestColumnTypeDatabaseTypeNameMore(t *testing.T) {
 // Reference: docs/third_party/googlesql-docs/data-types.md — STRUCT field
 // rendering is positional in the GoogleSQL compliance suite.
 func TestScanStructArrayIntoAny(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=scan_any_array_struct")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -976,6 +993,7 @@ func TestScanStructArrayIntoAny(t *testing.T) {
 // Without this, the deep assignInterfaceValue path for nested
 // containers is not exercised.
 func TestScanArrayOfStructToAny(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=scan_array_of_struct")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1006,6 +1024,7 @@ func TestScanArrayOfStructToAny(t *testing.T) {
 // alias pass is that `CREATE TABLE` succeeds and the column accepts
 // INT64 values.
 func TestTypeAliasesIntInteger(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=type_aliases")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1052,6 +1071,7 @@ func TestTypeAliasesIntInteger(t *testing.T) {
 // INT64). The isAliasInTypePosition helper guards against rewriting
 // columns named "Int", "Integer" etc.
 func TestTypeAliasInCast(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=cast_alias")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1095,6 +1115,7 @@ func TestTypeAliasInCast(t *testing.T) {
 //	SELECT SAFE_CAST("apple" AS INT64) AS not_a_number;
 //	-> NULL
 func TestSafeCastInvalidReturnsNull(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=safe_cast_invalid")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1118,6 +1139,7 @@ func TestSafeCastInvalidReturnsNull(t *testing.T) {
 //
 // Same source as the NULL case (conversion_functions.md SAFE_CAST).
 func TestSafeCastValidPassesThrough(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=safe_cast_valid")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1148,6 +1170,7 @@ func TestSafeCastValidPassesThrough(t *testing.T) {
 // Expected behaviour: SELECT NUMERIC '1' / NUMERIC '0' yields a
 // non-nil error containing "Div".
 func TestNumericDivisionByZeroReturnsError(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=numeric_divzero")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1173,6 +1196,7 @@ func TestNumericDivisionByZeroReturnsError(t *testing.T) {
 // through a BIGNUMERIC operand — NumericValue.Div handles both
 // NUMERIC and BIGNUMERIC values.
 func TestBignumericDivisionByZeroReturnsError(t *testing.T) {
+	t.Parallel()
 	db, err := sql.Open("googlesqlite", ":memory:?_test=bignumeric_divzero")
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
@@ -1190,6 +1214,7 @@ func TestBignumericDivisionByZeroReturnsError(t *testing.T) {
 // ---- from tests/parity/timestamp_test.go ----
 
 func TestTimestamp(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name      string
 		timestamp string
@@ -1210,7 +1235,6 @@ func TestTimestamp(t *testing.T) {
 		{name: "canonical microsecond", timestamp: "2020-06-02 14:58:40.123000+00", expected: "2020-06-02T14:58:40.123000Z"},
 		{name: "canonical now-shape", timestamp: "2026-05-14 01:31:31.392415+00", expected: "2026-05-14T01:31:31.392415Z"},
 	} {
-		os.Setenv("TZ", "UTC")
 		t.Run(test.name, func(t *testing.T) {
 			ti, err := googlesqlite.TimeFromTimestampValue(test.timestamp)
 			if err != nil {


### PR DESCRIPTION
## Problem

The `test` job runs ~12m47s. Two independent root causes.

### 1. Broken Go module/build caching

All three jobs (`test`/`lint`/`validate`) relied on `actions/setup-go`'s built-in cache, which keys solely on `go.sum` — so they shared **one immutable cache key**. The shortest job (`validate`) wins the post-step save race and freezes a **~16 MB near-empty snapshot** for every job. Result: `make build` runs cold every time (1m31s), and `go test -race` recompiles every dependency with race instrumentation from scratch.

### 2. The top-level package runs serially

The top-level `googlesqlite` package alone takes ~488s of the Test step. ~200 test functions across `ddl/dml/functions/query/types/regression` lack `t.Parallel()`, so they run serially in one process.

## Changes

**CI caching** (`.github/workflows/ci.yml`):
- `cache: false` on `setup-go`; explicit per-job `actions/cache` steps instead.
- Module cache keyed on `go.sum`.
- Build cache key carries `github.sha` so every run re-saves a fresh cache (the Actions cache is immutable — a hit never updates), with `restore-keys` restoring the newest match. Saved after `make test`, so it captures the `-race` object namespace separate from the non-race `make build` output.
- `lint` also gets a golangci-lint analysis cache.

**Test parallelization:**
- `t.Parallel()` added to all ~205 top-level test functions in the 6 files. Each test opens its own private database (`:memory:`, unique `_test=` labels, `cache=private`, or `os.CreateTemp`), so they are independent.
- Process timezone pinned to UTC once in `TestMain` instead of per-test `t.Setenv`/`os.Setenv` (`t.Setenv` is incompatible with `t.Parallel()`).

## Measured CI results

| | before | after (warm cache) |
|---|---|---|
| `test` job total | 12m47s | **8m17s** |
| ├ Build step | 1m31s | **4s** |
| ├ Test step | 11m02s | **7m43s** |
| `lint` job total | 3m09s | **~25s** |

The win is almost entirely the **caching fix**: cold `make build` 100s → 4s, and the `-race` recompilation inside `make test` (~180s) is now cached.

**Parallelization** moves the top-level package's pure runtime from 488s to 457s in CI — only ~6%. On a 4-core runner it is capped because the GoogleSQL analyzer in `go-googlesql` is a single global wasm module guarded by one `sync.Mutex`, so all of a process's parallel tests serialize on analysis. (On a 10-core dev machine the same change measures 488s → 302s.) The change is still correct and helps dev machines and larger runners; cutting CI below ~8m requires making the analyzer concurrent.

## Verification

`go test -race` on the top-level package passes — the race detector confirms no shared-state races were introduced by `t.Parallel()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
