### PR TITLE
Fix CodeQL incorrect-integer-conversion alert (#86)

### DIFF
--- a/internal/functions/spanner/mysql_helpers_extra.go
+++ b/internal/functions/spanner/mysql_helpers_extra.go
@@ -1126,7 +1126,10 @@ func jsonDecodeString(s string) (string, bool) {
 			if i+4 >= len(s) {
 				return "", false
 			}
-			n, err := strconv.ParseUint(s[i+1:i+5], 16, 32)
+			// A \uXXXX escape is exactly four hex digits — a 16-bit
+			// UTF-16 code unit — so parse with bitSize 16. That bounds
+			// n to 0xFFFF and makes the rune (int32) conversion safe.
+			n, err := strconv.ParseUint(s[i+1:i+5], 16, 16)
 			if err != nil {
 				return "", false
 			}


### PR DESCRIPTION
Resolves the one remaining open code-scanning alert.

**Alert #86** — `go/incorrect-integer-conversion`, `internal/functions/spanner/mysql_helpers_extra.go:1133`:

> Incorrect conversion of an unsigned 32-bit integer from `strconv.ParseUint` to a lower bit size type `int32` without an upper bound check.

In the `\uXXXX` branch of the MySQL-style JSON string unescaper, `n` was parsed with `strconv.ParseUint(s[i+1:i+5], 16, 32)` and then converted to `rune` (int32). CodeQL flags this because a 32-bit unsigned value can exceed the `int32` range.

A `\uXXXX` escape is always exactly four hex digits — a 16-bit UTF-16 code unit — so the correct `bitSize` is `16`. That bounds `n` to `0xFFFF`, which fits in `rune` safely.

**No behavior change:** four hex digits never exceed `0xFFFF`, so `bitSize 16` rejects nothing that `bitSize 32` accepted. `go test ./internal/functions/spanner/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
