### PR TITLE
Drop wasm-opt from the Playground build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # wasm builds the wasm-opt-optimised js/wasm Playground engine
-  # through the reusable workflow that release-test also uses — a
-  # single definition of the wasm build. The release and deploy-pages
-  # jobs consume its artifact, so the published engine and the engine
-  # embedded in the hosted Playground are the exact same build.
+  # wasm builds the js/wasm Playground engine through the reusable
+  # workflow that release-test also uses — a single definition of the
+  # wasm build. The release and deploy-pages jobs consume its artifact,
+  # so the published engine and the engine embedded in the hosted
+  # Playground are the exact same build.
   wasm:
     uses: ./.github/workflows/wasm.yml
     with:
-      optimize: true
+      upload: true
 
   # release publishes the cross-platform CLI archives with GoReleaser
   # and attaches the engine binary the wasm job produced — it downloads

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -2,18 +2,18 @@ name: wasm
 
 # Reusable workflow that builds the js/wasm Playground engine — and
 # nothing else. It is the single definition of the wasm build: the
-# release-test workflow calls it as a fast compile-only check, and the
-# release workflow calls it with optimize=true to produce the
-# wasm-opt-optimised engine, which the release then consumes as an
-# artifact. The bundled static site is built separately by the release
-# workflow, so this job needs no Node toolchain.
+# release-test workflow calls it as a compile-only check, and the
+# release workflow calls it with upload=true to publish the engine as
+# an artifact the release then consumes. The bundled static site is
+# built separately by the release workflow, so this job needs no Node
+# toolchain.
 on:
   workflow_call:
     inputs:
-      optimize:
+      upload:
         description: >-
-          When true, optimise the engine with wasm-opt and upload it as
-          an artifact. When false, only compile-check the js/wasm build.
+          When true, upload the built engine as an artifact for the
+          release. When false, only compile-check the js/wasm build.
         type: boolean
         default: false
 
@@ -34,20 +34,12 @@ jobs:
           go-version: stable
           cache-dependency-path: go.sum
 
-      # Fast path: confirm cmd/googlesqlite still compiles to js/wasm.
-      - name: Compile-check the engine
-        if: ${{ !inputs.optimize }}
+      - name: Build the js/wasm engine
         working-directory: docs/playground
         run: make build/wasm
 
-      # Release path: the wasm-opt-optimised engine binary.
-      - name: Build the optimised engine
-        if: ${{ inputs.optimize }}
-        working-directory: docs/playground
-        run: make build/engine
-
       - name: Upload the Playground engine
-        if: ${{ inputs.optimize }}
+        if: ${{ inputs.upload }}
         uses: actions/upload-artifact@v4
         with:
           name: playground-engine

--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,6 @@ go.work.sum
 # GoReleaser build output (`make release`, `make release/check`).
 /dist/
 
-# Binaryen release downloaded by docs/playground/Makefile (provides
-# wasm-opt). Pinned and reproducible, so it is fetched, not tracked.
-/tools/binaryen-*
-
 # Stray top-level binaries from `go build ./cmd/...`
 /specctl
 /googlesqlite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,21 +53,6 @@ Currently managed tools:
 - `github.com/golangci/golangci-lint/v2/cmd/golangci-lint`
 - `github.com/goreleaser/goreleaser/v2` (run via `make release`)
 
-### Non-Go tools
-
-Tools that are not Go programs cannot live in `tools/go.mod`. They MUST
-still be pinned and obtained by a single mechanism shared between local
-builds and CI — never an ad-hoc `brew install` locally versus a
-different install path in a workflow.
-
-Currently the only such tool is **Binaryen** (`wasm-opt`, used to
-optimise the Playground engine). It is pinned and downloaded entirely
-by `docs/playground/Makefile`: `BINARYEN_VERSION` pins the release and
-the `$(WASMOPT)` file target downloads, checksum-verifies and unpacks
-it under `tools/binaryen-<version>/` on demand. `make optimize` (and
-therefore `make build/release` and `make release`) depends on that
-target, so the release workflow needs no separate install step.
-
 ## Compatibility
 
 This project provides a `database/sql` driver registered as

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ GORELEASER_PARALLELISM := 1
 # docs/playground/public/googlesqlite.wasm — GoReleaser attaches it to
 # the release. The release workflow builds it in a dedicated `wasm`
 # job and hands it to the release job as an artifact; to publish from
-# a local checkout, run `make -C docs/playground deps build/release`
-# first. GITHUB_TOKEN must be set in the environment.
+# a local checkout, run `make -C docs/playground build/wasm` first.
+# GITHUB_TOKEN must be set in the environment.
 release:
 	$(GORELEASER) release --clean --parallelism $(GORELEASER_PARALLELISM)
 
@@ -99,4 +99,4 @@ identity-check:
 	fi
 
 clean:
-	rm -rf $(BIN) tools/binaryen-*
+	rm -rf $(BIN)

--- a/docs/playground/Makefile
+++ b/docs/playground/Makefile
@@ -1,60 +1,19 @@
 # Makefile for the googlesqlite Playground.
 #
 # Typical first run:
-#   make deps           # install npm dependencies
-#   make dev            # build the wasm, then start the Vite dev server
+#   make deps    # install npm dependencies
+#   make dev     # build the engine, then start the Vite dev server
 #
 # `make build` produces the static site under dist/.
-# `make build/release` produces the wasm-opt-optimised site that the
-# release workflow deploys to GitHub Pages.
 
 # Repository root, relative to this directory.
 ROOT   := ../..
 PUBLIC := public
 WASM   := $(PUBLIC)/googlesqlite.wasm
 
-# Binaryen provides wasm-opt. It is a C++ tool, so it cannot live in
-# tools/go.mod alongside the Go tools; instead a pinned release is
-# downloaded on demand by the $(WASMOPT) rule below. The version is
-# part of the install directory name, so bumping BINARYEN_VERSION
-# triggers a fresh download while an existing install is reused as-is.
-# This is the single mechanism shared by local builds and CI — there is
-# no separate install step.
-BINARYEN_VERSION := version_129
-
-# Map the host to Binaryen's release-asset naming. uname -m reports
-# x86_64/amd64 or arm64/aarch64; Binaryen labels its arm assets arm64
-# on macOS but aarch64 on Linux.
-binaryen_os   := $(if $(filter Darwin,$(shell uname -s)),macos,linux)
-binaryen_arch := $(if $(filter x86_64 amd64,$(shell uname -m)),x86_64,$(if $(filter macos,$(binaryen_os)),arm64,aarch64))
-
-BINARYEN_DIR     := $(ROOT)/tools/binaryen-$(BINARYEN_VERSION)
-WASMOPT          := $(BINARYEN_DIR)/bin/wasm-opt
-binaryen_tarball := binaryen-$(BINARYEN_VERSION)-$(binaryen_arch)-$(binaryen_os).tar.gz
-binaryen_baseurl := https://github.com/WebAssembly/binaryen/releases/download/$(BINARYEN_VERSION)
-
-.PHONY: build build/release build/engine build/wasm build/assets build/page \
-        deps dev preview optimize clean
+.PHONY: build build/wasm build/assets build/page deps dev preview clean
 
 build: build/wasm build/assets build/page
-
-# build/engine produces just the optimised engine binary
-# (public/googlesqlite.wasm): compile, then shrink it with wasm-opt. It
-# carries no compressed copy, build id or bundled site. The release
-# workflow builds the engine and the site in separate jobs, so the two
-# halves are kept separable here too.
-build/engine:
-	$(MAKE) build/wasm
-	$(MAKE) optimize
-
-# build/release produces the full optimised static site for a local
-# deployment build: the optimised engine, then the derived assets and
-# the bundled site. The sub-makes run in sequence so the build id and
-# the .gz always describe the exact binary that ships.
-build/release:
-	$(MAKE) build/engine
-	$(MAKE) build/assets
-	$(MAKE) build/page
 
 # build/wasm compiles the js/wasm Playground entrypoint
 # (cmd/googlesqlite, the `js && wasm` build) to public/googlesqlite.wasm
@@ -66,12 +25,10 @@ build/wasm:
 	  -o docs/playground/$(WASM) ./cmd/googlesqlite
 	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" $(PUBLIC)/wasm_exec.js
 
-# build/assets derives the artifacts that depend on the final binary:
+# build/assets derives the artifacts that depend on the engine binary:
 # the packed timezone database, the content-hash build id, and the
 # pre-compressed .gz copy the server delivers (mirroring a deploy that
-# ships the compressed artifact). Run it after build/wasm — and after
-# optimize, when optimising — so the build id and the .gz describe the
-# binary that actually ships.
+# ships the compressed artifact). Run it after build/wasm.
 build/assets:
 	node scripts/pack-zoneinfo.mjs
 	node scripts/build-id.mjs
@@ -91,7 +48,7 @@ build/page:
 deps:
 	npm install
 
-# dev builds the wasm and starts the Vite dev server. The page is
+# dev builds the engine and starts the Vite dev server. The page is
 # served at http://localhost:5173/googlesqlite/.
 dev: build/wasm build/assets
 	npm run dev
@@ -99,35 +56,6 @@ dev: build/wasm build/assets
 # preview serves the production build from dist/.
 preview:
 	npm run preview
-
-# $(WASMOPT) downloads and checksum-verifies the pinned Binaryen
-# release. As a file target it runs only when wasm-opt is not already
-# installed; the version-stamped directory name makes a BINARYEN_VERSION
-# bump re-download. The tarball unpacks to binaryen-$(BINARYEN_VERSION)/,
-# which is $(BINARYEN_DIR).
-$(WASMOPT):
-	mkdir -p $(ROOT)/tools
-	cd $(ROOT)/tools && \
-	  curl -fsSL "$(binaryen_baseurl)/$(binaryen_tarball)" -o "$(binaryen_tarball)" && \
-	  curl -fsSL "$(binaryen_baseurl)/$(binaryen_tarball).sha256" -o "$(binaryen_tarball).sha256" && \
-	  shasum -a 256 -c "$(binaryen_tarball).sha256" && \
-	  tar -xzf "$(binaryen_tarball)" && \
-	  rm -f "$(binaryen_tarball)" "$(binaryen_tarball).sha256"
-
-# optimize runs wasm-opt over the built binary to shrink the code
-# section and speed up startup. wasm-opt comes from a pinned Binaryen
-# release (the $(WASMOPT) prerequisite), so no manual install is
-# needed. Note: most of the binary is embedded wasm module data (the
-# SQLite and GoogleSQL runtimes), which wasm-opt cannot compress —
-# expect a modest reduction.
-optimize: $(WASMOPT)
-	$(WASMOPT) -Oz \
-	  --enable-bulk-memory \
-	  --enable-nontrapping-float-to-int \
-	  --enable-sign-ext \
-	  --enable-mutable-globals \
-	  $(WASM) -o $(WASM)
-	@ls -lh $(WASM) | awk '{print "optimize: " $$9 " (" $$5 ")"}'
 
 clean:
 	rm -rf dist node_modules $(WASM) $(WASM).gz $(PUBLIC)/wasm_exec.js \

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -29,14 +29,9 @@ $ make dev       # build the wasm engine, then start the dev server
 ## Build the static site
 
 ```console
-$ make build         # builds the wasm engine and bundles the site into dist/
-$ make build/release # same, but shrinks the engine with wasm-opt first
-$ make preview       # serve the production build locally
+$ make build     # builds the engine and bundles the site into dist/
+$ make preview   # serve the production build locally
 ```
-
-`make build/release` is what the release workflow runs: it optimises
-the engine with `wasm-opt` before bundling, so it additionally needs
-Binaryen installed (see *Optimising the wasm binary* below).
 
 ## How it works
 
@@ -48,38 +43,19 @@ The worker (`src/api/worker.ts`) loads `wasm_exec.js`, instantiates the
 engine, and exposes `exec` / history / export calls. The UI thread
 talks to it through `src/api/googlesqlite.ts`.
 
-## Optimising the wasm binary
-
-The engine binary is large: it bundles the whole googlesqlite stack
-into one js/wasm module — SQLite (transpiled to Go) plus the GoogleSQL
-analyzer, which is itself an embedded wasm module run through wazero.
-`wasm-opt` (Binaryen) can shrink the code section and speed up
-start-up:
-
-```console
-$ make optimize   # runs wasm-opt over public/googlesqlite.wasm
-```
-
-`make optimize` needs no manual setup: the Makefile downloads and
-checksum-verifies a pinned Binaryen release (`BINARYEN_VERSION`) under
-`../../tools/binaryen-<version>/` on demand. Local builds and the
-release workflow share this one mechanism, so they optimise with the
-identical `wasm-opt`. `make build/release` runs this step for you.
-
-Most of the binary is the embedded GoogleSQL analyzer wasm module,
-which `wasm-opt` cannot compress further, so expect only a modest
-reduction.
-
 ## Deployment
 
 The site is deployed to GitHub Pages by the `Release` workflow
 (`.github/workflows/release.yml`) whenever a `v*` tag is pushed. The
-workflow runs `make build/release`, uploads `dist/` as the Pages
-artifact, and publishes it through `actions/deploy-pages`.
+workflow builds the engine, bundles the site, uploads `dist/` as the
+Pages artifact, and publishes it through `actions/deploy-pages`.
 
-The uncompressed engine binary exceeds GitHub's 100 MB per-file limit,
-but it is never deployed: the worker fetches the gzip-compressed
+The engine binary is large — it bundles the whole googlesqlite stack
+into one js/wasm module: SQLite (transpiled to Go) plus the GoogleSQL
+analyzer, which is itself an embedded wasm module run through wazero.
+The uncompressed binary exceeds GitHub's 100 MB per-file limit, but it
+is never deployed: the worker fetches the gzip-compressed
 `googlesqlite.wasm.gz` (tens of MB) and decompresses it in the browser,
 and `make build/page` drops the uncompressed copy from `dist/`. The
-same release workflow also attaches the optimised `googlesqlite.wasm`
-to the GitHub release as a downloadable asset.
+same release workflow also attaches `googlesqlite.wasm` to the GitHub
+release as a downloadable asset.


### PR DESCRIPTION
## Summary

The `v0.2.0` Release workflow failed: `wasm-opt -Oz` ran out of memory
on the GitHub-hosted runner while optimising the ~227 MB engine
binary, which killed the `wasm` job — so `release` and `deploy-pages`
were skipped and nothing published.

This drops the `wasm-opt` step.

## Why dropping it is fine

- The worker downloads the **gzip-compressed** engine; optimisation
  shrank that only from ~28 MB to ~25 MB, because the binary is
  dominated by an embedded wasm module `wasm-opt` cannot compress
  further (the README always called it a "modest reduction").
- The Playground behaves identically on the unoptimised engine — the
  whole Playwright e2e suite (chromium + webkit) has always run
  against the unoptimised build.

## Changes

- `docs/playground/Makefile`: remove the Binaryen download machinery
  and the `optimize` / `build/engine` / `build/release` targets.
- `wasm.yml`: the reusable workflow's `optimize` input becomes
  `upload` — with `wasm-opt` gone it only controls whether the engine
  artifact is uploaded.
- Drop the now-empty "Non-Go tools" section from `CLAUDE.md` and the
  `wasm-opt` docs from the Playground README.

## After merge

`v0.2.0` must be re-released from the fixed `main` — the tag currently
points at the commit whose workflow failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
