### PR TITLE
Ship wasm_exec.js in the Playground engine artifact

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -38,10 +38,16 @@ jobs:
         working-directory: docs/playground
         run: make build/wasm
 
+      # The engine artifact carries both the wasm binary and its
+      # matching Go wasm_exec.js loader: the release and deploy-pages
+      # jobs only download this artifact, so a missing wasm_exec.js
+      # leaves the deployed site unable to start the engine.
       - name: Upload the Playground engine
         if: ${{ inputs.upload }}
         uses: actions/upload-artifact@v4
         with:
           name: playground-engine
-          path: docs/playground/public/googlesqlite.wasm
+          path: |
+            docs/playground/public/googlesqlite.wasm
+            docs/playground/public/wasm_exec.js
           retention-days: 1


### PR DESCRIPTION
## Problem

The deployed Playground failed to start:

> Failed to start the GoogleSQLite engine: Failed to fetch dynamically
> imported module: https://goccy.github.io/googlesqlite/wasm_exec.js

`wasm_exec.js` was missing from the deployed site.

## Cause

The `wasm` job builds the engine and uploads it as the
`playground-engine` artifact, but the artifact's `path` listed only
`googlesqlite.wasm`. `wasm_exec.js` — the Go loader that
`make build/wasm` copies from `GOROOT` — was left out. The
`deploy-pages` job only downloads that artifact, so the bundled site
shipped without `wasm_exec.js`, and the worker's dynamic `import()` of
it 404'd.

A local build never reproduces this (`make build/wasm` writes both
files into `public/`), so the Playwright e2e — which runs against a
local build — could not catch it.

## Fix

Include `wasm_exec.js` in the engine artifact, so the `release` and
`deploy-pages` jobs receive the engine and its matching loader
together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
