### PR TITLE
Document the browser Playground in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ The driver registers under `googlesqlite`. DSN is the underlying
 SQLite path (`:memory:`, a file path, or
 `file:foo.db?cache=shared`).
 
+## Playground
+
+Try GoogleSQLite in your browser, with nothing to install:
+
+**<https://goccy.github.io/googlesqlite/>**
+
+The Playground is the whole engine — GoogleSQL parsing, analysis, and
+the SQLite backend — compiled to WebAssembly and run entirely
+client-side. Highlights:
+
+- **No server, no install.** Every query is parsed, analyzed, and
+  executed inside the browser tab; nothing is sent anywhere.
+- **Responsive UI.** The engine runs in a Web Worker, so editing and
+  running queries never blocks the page.
+- **Persistent database.** The SQLite database lives in the Origin
+  Private File System (OPFS), so your tables and data survive page
+  reloads with no explicit save step.
+- **A real SQL editor**, with query history and result export.
+
+It is the quickest way to explore the supported GoogleSQL syntax and
+functions without setting up a Go environment.
+
 ## Status
 
 Every function and type is backed by a declarative spec under


### PR DESCRIPTION
## Summary

Add a **Playground** section to the README pointing to the GitHub Pages deployment (<https://goccy.github.io/googlesqlite/>) and explaining what it offers.

The section summarises the key characteristics:

- **No server, no install** — the whole engine (GoogleSQL parsing, analysis, SQLite backend) is compiled to WebAssembly and runs entirely client-side.
- **Responsive UI** — the engine runs in a Web Worker.
- **Persistent database** — the SQLite database lives in OPFS and survives reloads.
- **A real SQL editor** — with query history and result export.

Documentation-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)