### PR TITLE
Fix aggregates over an empty group returning NULL / a synthetic value

### DIFF
--- a/aggregate_empty_group_test.go
+++ b/aggregate_empty_group_test.go
@@ -1,0 +1,102 @@
+package googlesqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestRegression_AggregateOverEmptyGroup asserts that an aggregate
+// evaluated over zero input rows returns each aggregate's documented
+// zero value rather than NULL.
+//
+// Origin: aggregates were registered through ncruces'
+// CreateAggregateFunction, whose iter.Seq wrapper starts the user
+// coroutine lazily on the first Step. When a group has zero rows
+// SQLite invokes only the final callback, which stops the
+// never-started coroutine without ever running the aggregate, so the
+// function never calls ctx.Result* and SQLite reports NULL. As a
+// result COUNT(*) over an empty table returned NULL instead of 0.
+// RegisterAggregator now registers through CreateWindowFunction, which
+// constructs a fresh instance and calls Value even when Step never
+// ran. See internal/sqlitex.RegisterAggregator.
+func TestRegression_AggregateOverEmptyGroup(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("googlesqlite", ":memory:?_test=aggemptygroup")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "CREATE TABLE t (n INT64)"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+
+	// COUNT-family aggregates return 0, not NULL, over an empty input.
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{"count_star", "SELECT COUNT(*) FROM t"},
+		{"count_column", "SELECT COUNT(n) FROM t"},
+		{"count_star_where_false", "SELECT COUNT(*) FROM t WHERE FALSE"},
+		{"countif", "SELECT COUNTIF(n > 0) FROM t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got sql.NullInt64
+			if err := conn.QueryRowContext(ctx, tc.sql).Scan(&got); err != nil {
+				t.Fatalf("%s: %v", tc.sql, err)
+			}
+			if !got.Valid {
+				t.Fatalf("%s returned NULL; want 0", tc.sql)
+			}
+			if got.Int64 != 0 {
+				t.Fatalf("%s = %d; want 0", tc.sql, got.Int64)
+			}
+		})
+	}
+
+	// SUM/AVG/MIN/MAX over an empty input are legitimately NULL — the
+	// fix must not turn those into a zero value.
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{"sum", "SELECT SUM(n) FROM t"},
+		{"avg", "SELECT AVG(n) FROM t"},
+		{"min", "SELECT MIN(n) FROM t"},
+		{"max", "SELECT MAX(n) FROM t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got sql.NullInt64
+			if err := conn.QueryRowContext(ctx, tc.sql).Scan(&got); err != nil {
+				t.Fatalf("%s: %v", tc.sql, err)
+			}
+			if got.Valid {
+				t.Fatalf("%s = %d; want NULL", tc.sql, got.Int64)
+			}
+		})
+	}
+
+	// A non-empty table still aggregates correctly, and GROUP BY (where
+	// every emitted group has at least one row) is unaffected.
+	if _, err := conn.ExecContext(ctx, "INSERT INTO t (n) VALUES (1), (2), (3)"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+	var count, sum sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*), SUM(n) FROM t").Scan(&count, &sum); err != nil {
+		t.Fatalf("aggregate over filled table: %v", err)
+	}
+	if !count.Valid || count.Int64 != 3 {
+		t.Fatalf("COUNT(*) over filled table = %v; want 3", count)
+	}
+	if !sum.Valid || sum.Int64 != 6 {
+		t.Fatalf("SUM(n) over filled table = %v; want 6", sum)
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1512,18 +1512,14 @@ func TestPreparedCreateAndDML(t *testing.T) {
 		t.Fatalf("DELETE Exec: %v", err)
 	}
 
-	// Final assertion: table is empty. We assert via "no rows
-	// returned by a SELECT" rather than COUNT(*) — under googlesqlite
-	// COUNT(*) of an empty table returns NULL not 0 (a quirk of the
-	// analyzer's group-by-without-rows lowering), so use a row-stream
-	// probe instead.
-	probe, err := conn.QueryContext(ctx, "SELECT SingerId FROM Singers")
-	if err != nil {
-		t.Fatalf("probe Query: %v", err)
+	// Final assertion: table is empty. COUNT(*) over an empty table
+	// returns 0 (see TestRegression_AggregateOverEmptyGroup).
+	var remaining int64
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM Singers").Scan(&remaining); err != nil {
+		t.Fatalf("COUNT(*) Query: %v", err)
 	}
-	defer probe.Close()
-	if probe.Next() {
-		t.Fatalf("expected zero rows after DELETE; got at least one")
+	if remaining != 0 {
+		t.Fatalf("expected zero rows after DELETE; got %d", remaining)
 	}
 }
 

--- a/internal/function_register_aggregate.go
+++ b/internal/function_register_aggregate.go
@@ -10,7 +10,7 @@ import (
 )
 
 // aggregateFuncs lists every aggregate function the driver registers
-// via Conn.CreateAggregateFunction. The functions are grouped by
+// through sqlitex.RegisterAggregator. The functions are grouped by
 // their GoogleSQL reference category page:
 //
 //   - aggregate_functions.md

--- a/internal/functions/aggregate/array_agg.go
+++ b/internal/functions/aggregate/array_agg.go
@@ -27,6 +27,10 @@ func (f *ARRAY_AGG) Step(v value.Value, opt *helper.Option) error {
 }
 
 func (f *ARRAY_AGG) Done() (value.Value, error) {
+	// ARRAY_AGG over zero input rows is SQL NULL, not an empty array.
+	if len(f.values) == 0 {
+		return nil, nil
+	}
 	f.values = helper.SortAggregatedValues(f.values, f.opt)
 	if f.opt != nil && f.opt.Limit != nil {
 		minLen := min(*f.opt.Limit, int64(len(f.values)))

--- a/internal/functions/aggregate/array_concat_agg.go
+++ b/internal/functions/aggregate/array_concat_agg.go
@@ -27,6 +27,11 @@ func (f *ARRAY_CONCAT_AGG) Step(v *value.ArrayValue, opt *helper.Option) error {
 }
 
 func (f *ARRAY_CONCAT_AGG) Done() (value.Value, error) {
+	// ARRAY_CONCAT_AGG over zero input rows is SQL NULL, not an empty
+	// array.
+	if len(f.values) == 0 {
+		return nil, nil
+	}
 	f.values = helper.SortAggregatedValues(f.values, f.opt)
 
 	if f.opt != nil && f.opt.Limit != nil {

--- a/internal/functions/aggregate/bind.go
+++ b/internal/functions/aggregate/bind.go
@@ -116,7 +116,7 @@ func BindCountStar() func() *helper.Aggregator {
 
 func BindBitAndAgg() func() *helper.Aggregator {
 	return func() *helper.Aggregator {
-		fn := &BIT_AND_AGG{value.IntValue(-1)}
+		fn := &BIT_AND_AGG{}
 		return helper.NewAggregator(
 			func(args []value.Value, opt *helper.Option) error {
 				return fn.Step(args[0], opt)
@@ -130,7 +130,7 @@ func BindBitAndAgg() func() *helper.Aggregator {
 
 func BindBitOrAgg() func() *helper.Aggregator {
 	return func() *helper.Aggregator {
-		fn := &BIT_OR_AGG{-1}
+		fn := &BIT_OR_AGG{}
 		return helper.NewAggregator(
 			func(args []value.Value, opt *helper.Option) error {
 				return fn.Step(args[0], opt)
@@ -144,7 +144,7 @@ func BindBitOrAgg() func() *helper.Aggregator {
 
 func BindBitXorAgg() func() *helper.Aggregator {
 	return func() *helper.Aggregator {
-		fn := &BIT_XOR_AGG{1}
+		fn := &BIT_XOR_AGG{}
 		return helper.NewAggregator(
 			func(args []value.Value, opt *helper.Option) error {
 				return fn.Step(args[0], opt)
@@ -172,7 +172,7 @@ func BindCountIf() func() *helper.Aggregator {
 
 func BindLogicalAnd() func() *helper.Aggregator {
 	return func() *helper.Aggregator {
-		fn := &LOGICAL_AND{true}
+		fn := &LOGICAL_AND{}
 		return helper.NewAggregator(
 			func(args []value.Value, opt *helper.Option) error {
 				return fn.Step(args[0], opt)

--- a/internal/functions/aggregate/bind_test.go
+++ b/internal/functions/aggregate/bind_test.go
@@ -235,10 +235,11 @@ func TestBindLogicalAnd(t *testing.T) {
 		t.Fatalf("got %v", got)
 	}
 
-	// Empty → true (per docs: empty AND defaults to TRUE).
+	// Empty input over zero rows is NULL (BigQuery semantics): with no
+	// row observed there is no truth value to report.
 	a = newAgg(t, BindLogicalAnd())
-	if got := mustDone(t, a); got != true {
-		t.Fatalf("got %v", got)
+	if got := mustDone(t, a); got != nil {
+		t.Fatalf("empty LOGICAL_AND: got %v; want nil", got)
 	}
 }
 
@@ -264,10 +265,11 @@ func TestBindLogicalOr(t *testing.T) {
 		t.Fatalf("got %v", got)
 	}
 
-	// Empty → false.
+	// Empty input over zero rows is NULL (BigQuery semantics): with no
+	// row observed there is no truth value to report.
 	a = newAgg(t, BindLogicalOr())
-	if got := mustDone(t, a); got != false {
-		t.Fatalf("got %v", got)
+	if got := mustDone(t, a); got != nil {
+		t.Fatalf("empty LOGICAL_OR: got %v; want nil", got)
 	}
 }
 
@@ -346,8 +348,7 @@ func TestBindBitAggregates(t *testing.T) {
 	}
 
 	// BigQuery: BIT_XOR(5, 12, 10) = 5 ^ 12 ^ 10 = 0b0101 ^ 0b1100 ^
-	// 0b1010 = 0b0011 = 3. (We avoid 1 as the first input because
-	// the implementation uses 1 as an "uninitialised" sentinel.)
+	// 0b1010 = 0b0011 = 3.
 	a = newAgg(t, BindBitXorAgg())
 	stepN(t, a, int64(5), int64(12), int64(10))
 	if got := mustDone(t, a); got != int64(3) {
@@ -361,13 +362,19 @@ func TestBindBitAggregates(t *testing.T) {
 		t.Fatalf("got %v", got)
 	}
 
-	// Empty BIT_AND -> initial sentinel (-1). Per BigQuery semantics
-	// BIT_AND over zero rows is NULL, but this implementation surfaces
-	// the all-ones sentinel; the test pins the observable behaviour so
-	// any future fix is visible.
+	// BIT_AND / BIT_OR / BIT_XOR over zero input rows are NULL — there
+	// is no value to report (BigQuery semantics).
 	a = newAgg(t, BindBitAndAgg())
-	if got := mustDone(t, a); got != int64(-1) {
-		t.Fatalf("got %v", got)
+	if got := mustDone(t, a); got != nil {
+		t.Fatalf("empty BIT_AND: got %v; want nil", got)
+	}
+	a = newAgg(t, BindBitOrAgg())
+	if got := mustDone(t, a); got != nil {
+		t.Fatalf("empty BIT_OR: got %v; want nil", got)
+	}
+	a = newAgg(t, BindBitXorAgg())
+	if got := mustDone(t, a); got != nil {
+		t.Fatalf("empty BIT_XOR: got %v; want nil", got)
 	}
 }
 
@@ -406,6 +413,12 @@ func TestBindArrayAgg(t *testing.T) {
 	a = newAgg(t, BindArrayAgg())
 	if err := a.Step(nil); err == nil {
 		t.Fatal("expected error on NULL input")
+	}
+
+	// ARRAY_AGG over zero input rows is NULL, not an empty array.
+	a = newAgg(t, BindArrayAgg())
+	if got := mustDone(t, a); got != nil {
+		t.Fatalf("empty ARRAY_AGG: got %v; want nil", got)
 	}
 }
 
@@ -1007,6 +1020,12 @@ func TestBindArrayConcatAgg(t *testing.T) {
 	a = newAgg(t, BindArrayConcatAgg())
 	if err := a.Step(nil); err != nil {
 		t.Fatal(err)
+	}
+
+	// ARRAY_CONCAT_AGG over zero input rows is NULL, not an empty array.
+	a = newAgg(t, BindArrayConcatAgg())
+	if got := mustDone(t, a); got != nil {
+		t.Fatalf("empty ARRAY_CONCAT_AGG: got %v; want nil", got)
 	}
 }
 

--- a/internal/functions/aggregate/bit_or_agg.go
+++ b/internal/functions/aggregate/bit_or_agg.go
@@ -5,8 +5,12 @@ import (
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
+// BIT_OR_AGG accumulates the bitwise OR of every non-NULL input. val
+// stays nil until the first non-NULL Step so that BIT_OR over zero
+// input rows reports SQL NULL rather than a synthetic 0 — and so a
+// genuine input of -1 is not mistaken for "no value yet".
 type BIT_OR_AGG struct {
-	val int64
+	val value.Value
 }
 
 func (f *BIT_OR_AGG) Step(v value.Value, opt *helper.Option) error {
@@ -17,14 +21,18 @@ func (f *BIT_OR_AGG) Step(v value.Value, opt *helper.Option) error {
 	if err != nil {
 		return err
 	}
-	if f.val == -1 {
-		f.val = i64
-	} else {
-		f.val |= i64
+	if f.val == nil {
+		f.val = value.IntValue(i64)
+		return nil
 	}
+	curI64, err := f.val.ToInt64()
+	if err != nil {
+		return err
+	}
+	f.val = value.IntValue(curI64 | i64)
 	return nil
 }
 
 func (f *BIT_OR_AGG) Done() (value.Value, error) {
-	return value.IntValue(f.val), nil
+	return f.val, nil
 }

--- a/internal/functions/aggregate/bit_xor_agg.go
+++ b/internal/functions/aggregate/bit_xor_agg.go
@@ -5,8 +5,12 @@ import (
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
+// BIT_XOR_AGG accumulates the bitwise XOR of every non-NULL input. val
+// stays nil until the first non-NULL Step so that BIT_XOR over zero
+// input rows reports SQL NULL rather than a synthetic 0 — and so a
+// genuine input of 1 is not mistaken for "no value yet".
 type BIT_XOR_AGG struct {
-	val int64
+	val value.Value
 }
 
 func (f *BIT_XOR_AGG) Step(v value.Value, opt *helper.Option) error {
@@ -17,14 +21,18 @@ func (f *BIT_XOR_AGG) Step(v value.Value, opt *helper.Option) error {
 	if err != nil {
 		return err
 	}
-	if f.val == 1 {
-		f.val = i64
-	} else {
-		f.val ^= i64
+	if f.val == nil {
+		f.val = value.IntValue(i64)
+		return nil
 	}
+	curI64, err := f.val.ToInt64()
+	if err != nil {
+		return err
+	}
+	f.val = value.IntValue(curI64 ^ i64)
 	return nil
 }
 
 func (f *BIT_XOR_AGG) Done() (value.Value, error) {
-	return value.IntValue(f.val), nil
+	return f.val, nil
 }

--- a/internal/functions/aggregate/logical_and.go
+++ b/internal/functions/aggregate/logical_and.go
@@ -5,8 +5,11 @@ import (
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
+// LOGICAL_AND reports whether every non-NULL input is TRUE. v stays nil
+// until the first non-NULL Step so that LOGICAL_AND over zero input
+// rows reports SQL NULL rather than a synthetic TRUE.
 type LOGICAL_AND struct {
-	v bool
+	v value.Value
 }
 
 func (f *LOGICAL_AND) Step(cond value.Value, opt *helper.Option) error {
@@ -17,12 +20,18 @@ func (f *LOGICAL_AND) Step(cond value.Value, opt *helper.Option) error {
 	if err != nil {
 		return err
 	}
-	if !b {
-		f.v = false
+	if f.v == nil {
+		f.v = value.BoolValue(b)
+		return nil
 	}
+	cur, err := f.v.ToBool()
+	if err != nil {
+		return err
+	}
+	f.v = value.BoolValue(cur && b)
 	return nil
 }
 
 func (f *LOGICAL_AND) Done() (value.Value, error) {
-	return value.BoolValue(f.v), nil
+	return f.v, nil
 }

--- a/internal/functions/aggregate/logical_or.go
+++ b/internal/functions/aggregate/logical_or.go
@@ -5,8 +5,11 @@ import (
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
+// LOGICAL_OR reports whether any non-NULL input is TRUE. v stays nil
+// until the first non-NULL Step so that LOGICAL_OR over zero input
+// rows reports SQL NULL rather than a synthetic FALSE.
 type LOGICAL_OR struct {
-	v bool
+	v value.Value
 }
 
 func (f *LOGICAL_OR) Step(cond value.Value, opt *helper.Option) error {
@@ -17,12 +20,18 @@ func (f *LOGICAL_OR) Step(cond value.Value, opt *helper.Option) error {
 	if err != nil {
 		return err
 	}
-	if b {
-		f.v = true
+	if f.v == nil {
+		f.v = value.BoolValue(b)
+		return nil
 	}
+	cur, err := f.v.ToBool()
+	if err != nil {
+		return err
+	}
+	f.v = value.BoolValue(cur || b)
 	return nil
 }
 
 func (f *LOGICAL_OR) Done() (value.Value, error) {
-	return value.BoolValue(f.v), nil
+	return f.v, nil
 }

--- a/internal/sqlitex/sqlitex.go
+++ b/internal/sqlitex/sqlitex.go
@@ -12,7 +12,6 @@ package sqlitex
 import (
 	"errors"
 	"fmt"
-	"iter"
 	"reflect"
 
 	sqlite3 "github.com/ncruces/go-sqlite3"
@@ -97,15 +96,30 @@ func RegisterFunc(conn *sqlite3.Conn, name string, fn any, opts FunctionFlags) e
 	})
 }
 
-// RegisterAggregator registers an aggregate (or window-as-aggregate)
+// RegisterAggregator registers a plain (non-window) aggregate
 // function. ctor must be a Go function with signature `func() T` where
 // T has Step and Done methods matching the predecessor's shape
 // (variadic interface{} args; interface{} result on Done).
 //
-// Both standard aggregates and the predecessor's window-as-aggregate
-// emulation share this entry point. We hand the aggregator to ncruces'
-// CreateAggregateFunction (no Inverse method); native window-frame
-// optimisation can be added later via a second registration path.
+// Registration goes through ncruces' CreateWindowFunction rather than
+// CreateAggregateFunction. CreateAggregateFunction's iter.Seq wrapper
+// drives the user function from a coroutine that is started lazily on
+// the first Step: when a group has zero input rows SQLite invokes only
+// the final callback, which stops the never-started coroutine without
+// ever running the user function. The aggregate then never calls
+// ctx.Result*, so SQLite reports NULL — e.g. COUNT(*) over an empty
+// table yields NULL instead of 0.
+//
+// CreateWindowFunction has no such gap: ncruces constructs a fresh
+// aggregate instance and calls Value even when Step never ran, so an
+// empty group still produces each aggregate's zero value (COUNT -> 0,
+// SUM -> NULL, ...). windowAggSimpleAdapter forwards Step directly to
+// the instance (O(1) memory, unlike the buffered window adapter) and
+// calls Done on Value. It implements no Inverse method, so it is
+// registered as a plain aggregate; functions registered here are only
+// ever emitted by the formatter for non-OVER aggregates (window use
+// routes to the separately registered googlesqlite_window_* variants),
+// so SQLite never drives the inverse callback on them.
 func RegisterAggregator(conn *sqlite3.Conn, name string, ctor any, opts FunctionFlags) error {
 	cv := reflect.ValueOf(ctor)
 	if !cv.IsValid() || cv.Kind() != reflect.Func {
@@ -124,32 +138,10 @@ func RegisterAggregator(conn *sqlite3.Conn, name string, ctor any, opts Function
 	stepNArg := stepArgCount(stepMethod.Type())
 
 	flag := flagBits(opts)
-	return conn.CreateAggregateFunction(name, stepNArg, flag, func(ctx *sqlite3.Context, seq iter.Seq[[]sqlite3.Value]) {
+	return conn.CreateWindowFunction(name, stepNArg, flag, sqlite3.AggregateConstructor(func() sqlite3.AggregateFunction {
 		inst := cv.Call(nil)[0].Interface()
-		step, done, err := lookupStepDone(inst)
-		if err != nil {
-			ctx.ResultError(err)
-			return
-		}
-		for vargs := range seq {
-			args := decodeArgs(vargs)
-			rets := callMethod(step, args)
-			if err := lastError(rets); err != nil {
-				ctx.ResultError(err)
-				return
-			}
-		}
-		out := done.Call(nil)
-		if err := lastError(out); err != nil {
-			ctx.ResultError(err)
-			return
-		}
-		var result any
-		if len(out) >= 1 {
-			result = out[0].Interface()
-		}
-		applyResult(*ctx, result)
-	})
+		return &windowAggSimpleAdapter{inst: inst}
+	}))
 }
 
 // RegisterWindow registers a window-aggregate function backed by
@@ -194,12 +186,21 @@ func RegisterWindow(conn *sqlite3.Conn, name string, ctor any, opts FunctionFlag
 	}))
 }
 
-// windowAggSimpleAdapter wraps an aggregator with Step + Done. It is
-// only used when the wrapped instance ALSO has an Inverse method;
-// without Inverse, the buffered adapter takes over (see
-// newBufferedWindowAdapter) because ncruces' CreateWindowFunction
-// always wires up the SQLite x_inverse callback regardless of
-// whether the Go side implements it.
+// windowAggSimpleAdapter wraps an aggregator with Step + Done,
+// forwarding each Step straight to the instance and producing the
+// result from Done on Value. It carries no Inverse method, so ncruces
+// registers it as a plain aggregate.
+//
+// It backs two registration paths:
+//
+//   - RegisterAggregator, for plain (non-OVER) aggregates. These never
+//     receive an inverse callback from SQLite.
+//   - RegisterWindow, but only when the wrapped instance ALSO has an
+//     Inverse method (then windowAggAdapter embeds this and adds
+//     Inverse). A window aggregator without Inverse instead goes
+//     through newBufferedWindowAdapter, which replays buffered Step
+//     args, because SQLite drives the inverse callback for moving
+//     frames and a plain Step+Done aggregator cannot undo a Step.
 type windowAggSimpleAdapter struct {
 	inst    any
 	stepErr error

--- a/internal/sqlitex/sqlitex_test.go
+++ b/internal/sqlitex/sqlitex_test.go
@@ -237,7 +237,16 @@ func (s *sumIntWithInverse) Inverse(args ...any) error {
 	return nil
 }
 
-// TestRegisterAggregator drives the standard aggregate path.
+// TestRegisterAggregator drives the standard aggregate path, both over
+// a populated table and — critically — over an empty group.
+//
+// The empty-group case is a regression guard: an aggregate over zero
+// input rows must still invoke Done() exactly once (SQLite's final
+// callback runs even when Step never did), so a never-stepped
+// aggregator emits its zero value rather than NULL. RegisterAggregator
+// previously registered through ncruces' CreateAggregateFunction,
+// whose iter.Seq wrapper skipped the user function entirely for an
+// empty group; that made COUNT(*) over an empty table return NULL.
 func TestRegisterAggregator(t *testing.T) {
 	t.Parallel()
 	c := openConn(t)
@@ -248,7 +257,17 @@ func TestRegisterAggregator(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got := scalarResult(t, c, "SELECT sum_int(x) FROM t"); got != int64(6) {
-		t.Fatalf("got %v", got)
+		t.Fatalf("aggregate over populated table = %v; want 6", got)
+	}
+
+	// sumInt.Done returns int64(0) when it was never stepped. If the
+	// machinery skips Done() for the empty group, scalarResult sees
+	// SQLite's synthetic NULL instead.
+	if err := c.Exec("CREATE TABLE empty_t(x)"); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalarResult(t, c, "SELECT sum_int(x) FROM empty_t"); got != int64(0) {
+		t.Fatalf("aggregate over empty group = %v (%T); want int64(0) — Done() was not invoked", got, got)
 	}
 }
 

--- a/testdata/specs/googlesql/functions/aggregate/array_agg.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/array_agg.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [[1, 2, 3]]
+  - desc: empty input returns NULL
+    sql: SELECT ARRAY_AGG(x) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/array_concat_agg.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/array_concat_agg.yaml
@@ -11,3 +11,8 @@ cases:
     expected:
       rows:
         - [[1, 2, 3, 4]]
+  - desc: empty input returns NULL
+    sql: SELECT ARRAY_CONCAT_AGG(arr) FROM UNNEST([STRUCT([1, 2] AS arr)]) WHERE FALSE
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/avg.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/avg.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [2.0]
+  - desc: empty input returns NULL
+    sql: SELECT AVG(x) FROM UNNEST(CAST([] AS ARRAY<FLOAT64>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/bit_and.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/bit_and.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [1]
+  - desc: empty input returns NULL
+    sql: SELECT BIT_AND(x) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/bit_or.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/bit_or.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [7]
+  - desc: empty input returns NULL
+    sql: SELECT BIT_OR(x) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/bit_xor.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/bit_xor.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [170]
+  - desc: empty input returns NULL
+    sql: SELECT BIT_XOR(x) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/count.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/count.yaml
@@ -11,3 +11,13 @@ cases:
     expected:
       rows:
         - [3]
+  - desc: count of empty input is zero
+    sql: SELECT COUNT(x) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [0]
+  - desc: count star of empty input is zero
+    sql: SELECT COUNT(*) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [0]

--- a/testdata/specs/googlesql/functions/aggregate/countif.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/countif.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [2]
+  - desc: countif of empty input is zero
+    sql: SELECT COUNTIF(x > 2) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [0]

--- a/testdata/specs/googlesql/functions/aggregate/logical_and.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/logical_and.yaml
@@ -11,3 +11,8 @@ cases:
     expected:
       rows:
         - [false]
+  - desc: empty input returns NULL
+    sql: SELECT LOGICAL_AND(x) FROM UNNEST(CAST([] AS ARRAY<BOOL>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/logical_or.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/logical_or.yaml
@@ -11,3 +11,8 @@ cases:
     expected:
       rows:
         - [false]
+  - desc: empty input returns NULL
+    sql: SELECT LOGICAL_OR(x) FROM UNNEST(CAST([] AS ARRAY<BOOL>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/max.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/max.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [5]
+  - desc: empty input returns NULL
+    sql: SELECT MAX(x) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/min.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/min.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [1]
+  - desc: empty input returns NULL
+    sql: SELECT MIN(x) FROM UNNEST(CAST([] AS ARRAY<INT64>)) AS x
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/aggregate/string_agg.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/string_agg.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - ["a,b,c"]
+  - desc: empty input returns NULL
+    sql: SELECT STRING_AGG(x, ",") FROM UNNEST(CAST([] AS ARRAY<STRING>)) AS x
+    expected:
+      rows:
+        - [null]


### PR DESCRIPTION
## Summary

`SELECT COUNT(*)` over an empty table returned SQL `NULL` instead of the typed `INT64` `0`. `COUNT`/`COUNTIF` are non-nullable in GoogleSQL/BigQuery — they always return `0`, even for zero input rows. This regressed every downstream consumer that scans the column into a non-pointer integer (reported downstream as goccy/bigquery-emulator#468).

Investigating it surfaced a second, related family of defects in other aggregates.

## Root cause

`sqlitex.RegisterAggregator` registered every aggregate through ncruces/go-sqlite3's `CreateAggregateFunction`. Its `iter.Seq` wrapper drives the user function from a coroutine started lazily on the first `Step`. When a group has **zero input rows**, SQLite invokes only the final callback, which stops the never-started coroutine without ever running the aggregate body — so the aggregate never calls `ctx.Result*` and SQLite reports `NULL`.

`COUNT`/`COUNT_STAR`/`COUNTIF`'s `Done()` already returns `0` when never stepped; it simply never got called.

## Fixes

| Change | Detail |
|---|---|
| `RegisterAggregator` -> `CreateWindowFunction` | ncruces constructs a fresh aggregate instance and calls `Value` even when `Step` never ran, so an empty group produces each aggregate's zero value. `windowAggSimpleAdapter` forwards `Step` straight through (O(1) memory). |
| `BIT_AND` / `BIT_OR` / `BIT_XOR` | Seeded their accumulator with the identity element (`-1`, `-1`, `1`) and could not distinguish "no value yet" from a real input equal to the sentinel. Now hold a nil `value.Value` until the first non-NULL `Step`; empty input -> `NULL`. |
| `LOGICAL_AND` / `LOGICAL_OR` | Seeded their result with the identity truth value (`TRUE` / `FALSE`) and returned it unconditionally. Now hold a nil `value.Value` until the first non-NULL `Step`; empty input -> `NULL`. |
| `ARRAY_AGG` / `ARRAY_CONCAT_AGG` | Returned an empty array for an empty group; now return `NULL`. |

The `BIT_*`/`LOGICAL_*`/`ARRAY_AGG` defects were latent — masked while `RegisterAggregator` skipped `Done()` for empty groups. The new empty-input test coverage surfaced them immediately.

## Why the regression slipped through

The empty-input edge case was tested at the wrong layer (the aggregator structs, via `Done()` directly) but never through the SQLite registration shim, where the bug lived. The spec corpus had an empty-input case for `SUM` (where a buggy `NULL` happens to equal the correct `NULL`) but none for `COUNT`/`COUNTIF` (where the bug is visible). `driver_test.go` even documented the wrong behaviour as a "quirk" and probed emptiness via a row stream to work around it.

This PR closes that gap:

- `sqlitex.TestRegisterAggregator` now also exercises an aggregate over an empty table.
- The aggregate spec corpus gains empty-input cases for every aggregate.
- Unit tests that pinned the old (wrong) behaviour are corrected.

## Testing

- `go test ./...` — full suite green, including the spec conformance suite.
- New regression test `TestRegression_AggregateOverEmptyGroup` covers the `COUNT` family (`0`) and `SUM`/`AVG`/`MIN`/`MAX` (`NULL`) over empty input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
