### PR TITLE
EXPORT DATA: honor compression / header / field_delimiter / overwrite OPTIONS

### DIFF
--- a/export_data.go
+++ b/export_data.go
@@ -6,18 +6,23 @@ import (
 
 // ExportURIWriter opens an io.WriteCloser for an EXPORT DATA destination
 // URI. The engine uses it to materialize the rows produced by an
-// `EXPORT DATA OPTIONS(uri = '...', format = '...') AS <query>` statement.
-// See RegisterExportURIWriter.
+// `EXPORT DATA OPTIONS(uri = '...', format = '...', ...) AS <query>`
+// statement. See RegisterExportURIWriter.
 type ExportURIWriter = exportdata.URIWriter
+
+// ExportWriterOpts carries the EXPORT DATA OPTIONS that influence how the
+// destination is opened. Implementations of ExportURIWriter should honor
+// each field where it is meaningful to their scheme and ignore the rest.
+type ExportWriterOpts = exportdata.WriterOpts
 
 // RegisterExportURIWriter installs w as the writer for EXPORT DATA URIs
 // whose scheme matches scheme (case-insensitive). The "gs" scheme is
 // registered by default and writes to Google Cloud Storage (honoring
-// STORAGE_EMULATOR_HOST so a fake-gcs-server instance is reachable without
-// any extra wiring). Register additional schemes — typically "s3" or
-// "azure" for BigQuery Omni destinations — when the application targets
-// them; an EXPORT DATA against an unregistered scheme fails with a
-// descriptive error rather than silently dropping the export.
+// STORAGE_EMULATOR_HOST so a fake-gcs-server instance is reachable
+// without any extra wiring). Register additional schemes — typically
+// "s3" or "azure" for BigQuery Omni destinations — when the application
+// targets them; an EXPORT DATA against an unregistered scheme fails with
+// a descriptive error rather than silently dropping the export.
 //
 // Passing a nil writer unregisters the scheme. Registering an
 // already-registered scheme replaces the previous writer; this is by

--- a/export_data_test.go
+++ b/export_data_test.go
@@ -2,6 +2,7 @@ package googlesqlite_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"fmt"
@@ -62,7 +63,7 @@ func registerMemScheme(t *testing.T) (string, *memCapture) {
 		}
 	}
 	scheme := "mem-" + sanitized.String()
-	googlesqlite.RegisterExportURIWriter(scheme, func(_ context.Context, uri string) (io.WriteCloser, error) {
+	googlesqlite.RegisterExportURIWriter(scheme, func(_ context.Context, uri string, _ googlesqlite.ExportWriterOpts) (io.WriteCloser, error) {
 		u, err := url.Parse(uri)
 		if err != nil {
 			return nil, fmt.Errorf("%s://: invalid uri %q: %w", scheme, uri, err)
@@ -115,56 +116,55 @@ func TestExportDataErrorPaths(t *testing.T) {
 	}
 	defer conn.Close()
 
-	t.Run("missing uri is rejected", func(t *testing.T) {
-		_, err := conn.QueryContext(ctx,
-			`EXPORT DATA OPTIONS(format = 'CSV') AS SELECT 1 AS id`)
+	// expectErr is the per-subtest invariant: the statement must fail
+	// before the URI writer is opened, and the error string must name
+	// the offending option / clause. The defensive Close on any
+	// non-nil rows guards against a future regression where a
+	// previously-rejected statement starts succeeding silently — without
+	// it the leaked *sql.Rows would pin the parent connection and turn
+	// the failure into a multi-minute conn.Close deadlock rather than a
+	// crisp assertion failure.
+	expectErr := func(t *testing.T, sql, mustContain string) {
+		t.Helper()
+		rows, err := conn.QueryContext(ctx, sql)
+		if rows != nil {
+			rows.Close()
+		}
 		if err == nil {
-			t.Fatal("EXPORT DATA without `uri` should fail")
+			t.Fatalf("statement should have failed but succeeded: %s", sql)
 		}
-		if !containsFold(err.Error(), "uri") {
-			t.Fatalf("error %q does not mention `uri`", err)
+		if !containsFold(err.Error(), mustContain) {
+			t.Fatalf("error %q does not mention %q", err, mustContain)
 		}
+	}
+
+	t.Run("missing uri is rejected", func(t *testing.T) {
+		expectErr(t, `EXPORT DATA OPTIONS(format = 'CSV') AS SELECT 1 AS id`, "uri")
 	})
 
 	t.Run("unsupported format is rejected", func(t *testing.T) {
-		_, err := conn.QueryContext(ctx, fmt.Sprintf(
+		expectErr(t, fmt.Sprintf(
 			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'AVRO')
-             AS SELECT 1 AS id`, scheme))
-		if err == nil {
-			t.Fatal("EXPORT DATA with unsupported format should fail")
-		}
-		if !containsFold(err.Error(), "avro") {
-			t.Fatalf("error %q does not name the offending format", err)
-		}
+             AS SELECT 1 AS id`, scheme), "avro")
 	})
 
 	t.Run("unregistered scheme is rejected", func(t *testing.T) {
-		_, err := conn.QueryContext(ctx,
+		expectErr(t,
 			`EXPORT DATA OPTIONS(uri = 's3://x/y', format = 'CSV')
-             AS SELECT 1 AS id`)
-		if err == nil {
-			t.Fatal("EXPORT DATA against unregistered scheme should fail")
-		}
-		if !containsFold(err.Error(), "s3") {
-			t.Fatalf("error %q does not name the missing scheme", err)
-		}
+             AS SELECT 1 AS id`, "s3")
 	})
 
 	t.Run("unknown option is rejected", func(t *testing.T) {
-		// `overwrite` is a real BigQuery EXPORT DATA option, but the
-		// engine does not honor it today. Silently dropping it would
-		// let `overwrite = false` SQL pass through and overwrite the
-		// destination anyway, with no signal that the option had no
-		// effect — so unknown / unhonored options must fail explicitly.
-		_, err := conn.QueryContext(ctx, fmt.Sprintf(
-			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV', overwrite = false)
-             AS SELECT 1 AS id`, scheme))
-		if err == nil {
-			t.Fatal("EXPORT DATA with an unsupported option should fail")
-		}
-		if !containsFold(err.Error(), "overwrite") {
-			t.Fatalf("error %q does not name the unsupported option", err)
-		}
+		// Use a name that is definitively not in BigQuery's EXPORT DATA
+		// vocabulary so the test does not regress the day an option we
+		// happen to pick becomes supported (this exact bug bit us once:
+		// the test used `overwrite = false` as the "unknown" stand-in,
+		// then started silently succeeding the moment overwrite landed
+		// in the option-reader, leaking rows and deadlocking the
+		// connection on Close).
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV', not_a_real_option = false)
+             AS SELECT 1 AS id`, scheme), "not_a_real_option")
 	})
 
 	t.Run("known option as non-literal expression is rejected", func(t *testing.T) {
@@ -175,9 +175,12 @@ func TestExportDataErrorPaths(t *testing.T) {
 		// not drop the value and surface as "required option `uri` is
 		// missing" — that would mislead the caller about what is
 		// wrong.
-		_, err := conn.QueryContext(ctx, fmt.Sprintf(
+		rows, err := conn.QueryContext(ctx, fmt.Sprintf(
 			`EXPORT DATA OPTIONS(uri = CONCAT('%s://', 'x/y'), format = 'CSV')
              AS SELECT 1 AS id`, scheme))
+		if rows != nil {
+			rows.Close()
+		}
 		if err == nil {
 			t.Fatal("EXPORT DATA with non-literal `uri` should fail")
 		}
@@ -188,18 +191,189 @@ func TestExportDataErrorPaths(t *testing.T) {
 			t.Fatalf("error %q wrongly reports `uri` as missing when it was supplied non-literal", err)
 		}
 	})
+
+	t.Run("header on non-CSV format is rejected", func(t *testing.T) {
+		// `header` is documented as CSV-only; silently honouring it for
+		// JSON output would either drop the value (losing intent) or
+		// emit a column-name row that NDJSON readers cannot parse.
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'JSON', header = true)
+             AS SELECT 1 AS id`, scheme), "header")
+	})
+
+	t.Run("field_delimiter on non-CSV format is rejected", func(t *testing.T) {
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'JSON', field_delimiter = '|')
+             AS SELECT 1 AS id`, scheme), "field_delimiter")
+	})
+
+	t.Run("incompatible compression for format is rejected", func(t *testing.T) {
+		// SNAPPY is documented for AVRO/PARQUET, not CSV. The encoder
+		// would happily write uncompressed bytes if we dropped the value
+		// — that produces a file that does not match what the caller
+		// asked for.
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV', compression = 'SNAPPY')
+             AS SELECT 1 AS id`, scheme), "snappy")
+	})
+
+	t.Run("use_avro_logical_types names AVRO format gap", func(t *testing.T) {
+		// `use_avro_logical_types` is a real BigQuery option but only
+		// meaningful with AVRO output, which the encoder does not
+		// implement. The diagnostic should name the option (so the
+		// caller knows their input was understood) AND the format
+		// (so they know which gap to file).
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV', use_avro_logical_types = true)
+             AS SELECT 1 AS id`, scheme), "use_avro_logical_types")
+	})
+
+	t.Run("WITH CONNECTION is rejected", func(t *testing.T) {
+		// EXPORT DATA WITH CONNECTION `proj.region.conn` routes Omni
+		// exports through a caller-supplied IAM/credential binding.
+		// Silently ignoring the connection would route the export to
+		// whatever the URIWriter for the scheme picks by default,
+		// which is almost never what the caller meant.
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA WITH CONNECTION ` + "`proj.region.conn`" + ` OPTIONS(uri = '%s://x/y', format = 'CSV')
+             AS SELECT 1 AS id`, scheme), "connection")
+	})
 }
 
 // TestExportDataMemRoundTrip exercises the full EXPORT DATA path —
 // OPTIONS parsing, the inner query, format encoding, scheme dispatch,
 // writer Close — without any cloud dependency, by registering a
 // test-local in-memory URIWriter for the duration of the test and
-// asserting the bytes it captured.
+// asserting the bytes it captured. The subtests cover every OPTIONS
+// field that influences the emitted bytes (format, header,
+// field_delimiter, compression) so a regression in option plumbing
+// surfaces as a byte-level mismatch, not as silently-correct-looking
+// output that ignores the caller's intent.
 func TestExportDataMemRoundTrip(t *testing.T) {
-	scheme, capture := registerMemScheme(t)
+	cases := []struct {
+		name    string
+		options string  // body of OPTIONS(...) less the uri
+		key     string  // expected capture key (host/path of the uri)
+		decode  func(t *testing.T, raw []byte) []byte
+		want    string
+	}{
+		{
+			name:    "csv default",
+			options: `format = 'CSV'`,
+			key:     "target/out.csv",
+			want:    "id,name\n1,alice\n2,bob\n",
+		},
+		{
+			name:    "csv header suppressed",
+			options: `format = 'CSV', header = false`,
+			key:     "target/out.csv",
+			want:    "1,alice\n2,bob\n",
+		},
+		{
+			name:    "csv field_delimiter pipe",
+			options: `format = 'CSV', field_delimiter = '|'`,
+			key:     "target/out.csv",
+			want:    "id|name\n1|alice\n2|bob\n",
+		},
+		{
+			name:    "csv gzip compression",
+			options: `format = 'CSV', compression = 'GZIP'`,
+			key:     "target/out.csv.gz",
+			decode:  gunzip,
+			want:    "id,name\n1,alice\n2,bob\n",
+		},
+		{
+			name:    "newline-delimited json",
+			options: `format = 'JSON'`,
+			key:     "target/out.json",
+			want:    "{\"id\":1,\"name\":\"alice\"}\n{\"id\":2,\"name\":\"bob\"}\n",
+		},
+		{
+			name:    "json gzip compression",
+			options: `format = 'JSON', compression = 'GZIP'`,
+			key:     "target/out.json.gz",
+			decode:  gunzip,
+			want:    "{\"id\":1,\"name\":\"alice\"}\n{\"id\":2,\"name\":\"bob\"}\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme, capture := registerMemScheme(t)
+			ctx := context.Background()
+			db, err := sql.Open("googlesqlite", ":memory:?_test=exportdatamem")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			conn, err := db.Conn(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+
+			rows, err := conn.QueryContext(ctx, fmt.Sprintf(
+				`EXPORT DATA OPTIONS(uri = '%s://%s', %s)
+                 AS SELECT 1 AS id, 'alice' AS name UNION ALL SELECT 2, 'bob'`,
+				scheme, tc.key, tc.options,
+			))
+			if err != nil {
+				t.Fatalf("exec: %v", err)
+			}
+			defer rows.Close()
+			if rows.Next() {
+				t.Fatal("EXPORT DATA returned a row; want none")
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+
+			raw, ok := capture.get(tc.key)
+			if !ok {
+				t.Fatalf("captured no bytes at %s (have %v)", tc.key, capture.keys())
+			}
+			got := raw
+			if tc.decode != nil {
+				got = tc.decode(t, raw)
+			}
+			if string(got) != tc.want {
+				t.Errorf("captured = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExportDataOverwriteOption checks that the `overwrite` option
+// reaches the URIWriter via ExportWriterOpts. The mem writer here
+// refuses a second open at the same key unless opts.Overwrite is
+// true — modelling the GCS Conditions{DoesNotExist:true} the
+// built-in gs:// writer attaches when overwrite=false. The test
+// fails if EXPORT DATA strips the option somewhere between the
+// analyzer and the writer (which would silently overwrite real
+// objects in production).
+func TestExportDataOverwriteOption(t *testing.T) {
+	scheme := "mem-overwrite"
+	var (
+		mu     sync.Mutex
+		exists = map[string]bool{}
+	)
+	googlesqlite.RegisterExportURIWriter(scheme, func(_ context.Context, uri string, opts googlesqlite.ExportWriterOpts) (io.WriteCloser, error) {
+		u, err := url.Parse(uri)
+		if err != nil {
+			return nil, err
+		}
+		key := path.Join(u.Host, u.Path)
+		mu.Lock()
+		defer mu.Unlock()
+		if exists[key] && !opts.Overwrite {
+			return nil, fmt.Errorf("destination %s exists and overwrite=false", key)
+		}
+		exists[key] = true
+		return nopWriteCloser{}, nil
+	})
+	t.Cleanup(func() { googlesqlite.RegisterExportURIWriter(scheme, nil) })
 
 	ctx := context.Background()
-	db, err := sql.Open("googlesqlite", ":memory:?_test=exportdatamem")
+	db, err := sql.Open("googlesqlite", ":memory:?_test=exportoverwrite")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,29 +384,53 @@ func TestExportDataMemRoundTrip(t *testing.T) {
 	}
 	defer conn.Close()
 
-	rows, err := conn.QueryContext(ctx, fmt.Sprintf(
-		`EXPORT DATA OPTIONS(uri = '%s://target/out.csv', format = 'CSV')
-         AS SELECT 1 AS id, 'alice' AS name UNION ALL SELECT 2, 'bob'`,
-		scheme,
-	))
+	stmt := fmt.Sprintf(
+		`EXPORT DATA OPTIONS(uri = '%s://b/out.csv', format = 'CSV', overwrite = %%s)
+         AS SELECT 1 AS id`, scheme)
+
+	// First write — fresh destination; should succeed regardless of
+	// the overwrite flag.
+	r1, err := conn.QueryContext(ctx, fmt.Sprintf(stmt, "false"))
 	if err != nil {
-		t.Fatalf("exec: %v", err)
+		t.Fatalf("first export: %v", err)
 	}
-	defer rows.Close()
-	if rows.Next() {
-		t.Fatal("EXPORT DATA returned a row; want none")
+	r1.Close()
+
+	// Second write at the same URI with overwrite=false — the writer
+	// is supposed to refuse. If the option is silently dropped the
+	// writer would see opts.Overwrite=false but already-exists=true
+	// and the inner refusal still fires, so this also fails. The bug
+	// we are guarding against is the opposite: an opts.Overwrite=true
+	// value silently being downgraded to false (or vice versa). Cover
+	// both directions below.
+	r2, err := conn.QueryContext(ctx, fmt.Sprintf(stmt, "false"))
+	if r2 != nil {
+		r2.Close()
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("rows.Err: %v", err)
+	if err == nil {
+		t.Fatal("second EXPORT DATA with overwrite=false should fail; URIWriter returned no error so the option must have been silently flipped to true")
 	}
 
-	got, ok := capture.get("target/out.csv")
-	if !ok {
-		t.Fatalf("captured no bytes at target/out.csv (have %v)", capture.keys())
+	// Same destination, this time with overwrite=true — must succeed.
+	r3, err := conn.QueryContext(ctx, fmt.Sprintf(stmt, "true"))
+	if err != nil {
+		t.Fatalf("EXPORT DATA with overwrite=true should succeed: %v", err)
 	}
-	if want := "id,name\n1,alice\n2,bob\n"; string(got) != want {
-		t.Errorf("captured = %q; want %q", got, want)
+	r3.Close()
+}
+
+func gunzip(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	r, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("gzip header: %v", err)
 	}
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("gunzip: %v", err)
+	}
+	return out
 }
 
 func containsFold(haystack, needle string) bool {

--- a/export_data_test.go
+++ b/export_data_test.go
@@ -238,6 +238,66 @@ func TestExportDataErrorPaths(t *testing.T) {
 			`EXPORT DATA WITH CONNECTION `+"`proj.region.conn`"+` OPTIONS(uri = '%s://x/y', format = 'CSV')
              AS SELECT 1 AS id`, scheme), "connection")
 	})
+
+	// Reverse-ETL destination formats — BigQuery accepts CLOUD_SPANNER /
+	// CLOUD_BIGTABLE / CLOUD_PUBSUB / ALLOYDB to push rows into
+	// operational stores. The googlesqlite engine has no managed
+	// connector for any of them, so each must surface as a named error
+	// (caller learns "this destination, specifically") rather than a
+	// vague "unknown format" message.
+	for _, fmtName := range []string{"CLOUD_SPANNER", "CLOUD_BIGTABLE", "CLOUD_PUBSUB", "ALLOYDB"} {
+		fmtName := fmtName
+		t.Run("reverse-ETL format "+fmtName+" is named in the error", func(t *testing.T) {
+			expectErr(t, fmt.Sprintf(
+				`EXPORT DATA OPTIONS(uri = 'https://example.googleapis.com/x', format = '%s')
+                 AS SELECT 1 AS id`, fmtName), fmtName)
+		})
+	}
+
+	t.Run("spanner_options names the destination gap", func(t *testing.T) {
+		// `spanner_options` is the JSON-encoded STRING that configures
+		// `format = 'CLOUD_SPANNER'` exports (table name, request
+		// priority, change-timestamp column, …). Dropping it silently
+		// would lose schema-level config; falling through to the
+		// generic "unknown option" message would hide that we DO know
+		// about the option but lack the destination connector. The
+		// diagnostic must name the option AND the destination class.
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV',
+                                 spanner_options = '{"table":"t","priority":"MEDIUM"}')
+             AS SELECT 1 AS id`, scheme), "spanner_options")
+	})
+
+	t.Run("bigtable_options names the destination gap", func(t *testing.T) {
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV',
+                                 bigtable_options = '{"columnFamilies":[]}')
+             AS SELECT 1 AS id`, scheme), "bigtable_options")
+	})
+
+	t.Run("alloydb_options names the destination gap", func(t *testing.T) {
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV',
+                                 alloydb_options = '{"schema":"public","table":"t"}')
+             AS SELECT 1 AS id`, scheme), "alloydb_options")
+	})
+
+	t.Run("auto_create_column_families names the Bigtable gap", func(t *testing.T) {
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV', auto_create_column_families = true)
+             AS SELECT 1 AS id`, scheme), "auto_create_column_families")
+	})
+
+	t.Run("reverse-ETL option with wrong literal type is reported by name", func(t *testing.T) {
+		// Type-check fires BEFORE the destination-gap message, so the
+		// error names the option AND the expected literal type. This
+		// is the same shape as `header = 'yes'` — without it a misuse
+		// like `spanner_options = 42` would surface as "format
+		// CLOUD_SPANNER not supported" which buries the original mistake.
+		expectErr(t, fmt.Sprintf(
+			`EXPORT DATA OPTIONS(uri = '%s://x/y', format = 'CSV', spanner_options = 42)
+             AS SELECT 1 AS id`, scheme), "spanner_options")
+	})
 }
 
 // TestExportDataMemRoundTrip exercises the full EXPORT DATA path —

--- a/export_data_test.go
+++ b/export_data_test.go
@@ -235,7 +235,7 @@ func TestExportDataErrorPaths(t *testing.T) {
 		// whatever the URIWriter for the scheme picks by default,
 		// which is almost never what the caller meant.
 		expectErr(t, fmt.Sprintf(
-			`EXPORT DATA WITH CONNECTION ` + "`proj.region.conn`" + ` OPTIONS(uri = '%s://x/y', format = 'CSV')
+			`EXPORT DATA WITH CONNECTION `+"`proj.region.conn`"+` OPTIONS(uri = '%s://x/y', format = 'CSV')
              AS SELECT 1 AS id`, scheme), "connection")
 	})
 }
@@ -252,8 +252,8 @@ func TestExportDataErrorPaths(t *testing.T) {
 func TestExportDataMemRoundTrip(t *testing.T) {
 	cases := []struct {
 		name    string
-		options string  // body of OPTIONS(...) less the uri
-		key     string  // expected capture key (host/path of the uri)
+		options string // body of OPTIONS(...) less the uri
+		key     string // expected capture key (host/path of the uri)
 		decode  func(t *testing.T, raw []byte) []byte
 		want    string
 	}{

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -2335,22 +2335,34 @@ func (a *Analyzer) newCreateTableFunctionStmtAction(ctx context.Context, _ strin
 }
 
 // newExportDataStmtAction lowers an
-// `EXPORT DATA OPTIONS(uri = '...', format = '...') AS <query>` statement
-// into an ExportDataStmtAction. The OPTIONS clause is parsed off the
-// resolved AST (uri is required, format defaults to CSV — matching real
-// BigQuery), the inner query is formatted in the usual way, and the action
-// at execute time runs the inner query and streams its rows through the
-// format encoder into the writer registered for the URI's scheme (see
-// exportdata.RegisterURIWriter).
+// `EXPORT DATA OPTIONS(...) AS <query>` statement into an
+// ExportDataStmtAction. The OPTIONS clause is parsed off the resolved AST
+// (`uri` is required, `format` defaults to CSV — matching real BigQuery),
+// the inner query is formatted in the usual way, and the action at execute
+// time runs the inner query and streams its rows through the format
+// encoder, optional compression wrapper and the writer registered for the
+// URI's scheme.
 func (a *Analyzer) newExportDataStmtAction(ctx context.Context, query string, args []driver.NamedValue, node *googlesql.ResolvedExportDataStmt) (StmtAction, error) {
-	uri, formatStr, err := readExportDataOptions(ctx, m1(node.OptionList()))
-	if err != nil {
-		return nil, err
+	// WITH CONNECTION <name> selects a BigQuery Omni connection for
+	// `s3://` / `azure://...` destinations. The connection identity is a
+	// caller-supplied credential — silently dropping it would route
+	// the export to whatever the URIWriter for that scheme picks by
+	// default, which is almost never what the caller meant. Reject it
+	// here; if a caller needs connection-based routing they should
+	// register a scheme-specific URIWriter that resolves the connection
+	// out-of-band.
+	if conn, _ := node.Connection(); conn != nil {
+		return nil, fmt.Errorf("EXPORT DATA: WITH CONNECTION is not supported by googlesqlite (register a scheme-specific URIWriter to handle this destination)")
 	}
-	if uri == "" {
-		return nil, fmt.Errorf("EXPORT DATA: required option `uri` is missing")
-	}
-	format, err := exportdata.ParseFormat(formatStr)
+	// IsValueTable is NOT rejected up-front: real BigQuery accepts
+	// `EXPORT DATA AS (SELECT AS STRUCT ...)` and similar value-table
+	// queries (the OutputColumnList carries the struct's fields as
+	// columns, so the format encoders below render the same per-row
+	// shape BigQuery emits). Any encoder-specific gap that surfaces
+	// for an exotic value-table value (e.g. a top-level ARRAY in CSV)
+	// will be caught by that encoder, matching how BigQuery itself
+	// rejects nested data in CSV — see ParseFormat / encodeCSV.
+	resolved, err := readExportDataOptions(m1(node.OptionList()))
 	if err != nil {
 		return nil, err
 	}
@@ -2373,73 +2385,177 @@ func (a *Analyzer) newExportDataStmtAction(ctx context.Context, query string, ar
 	if err != nil {
 		return nil, err
 	}
-	return NewExportDataStmtAction(query, formattedQuery, params, queryArgs, outputColumns, uri, format), nil
+	return NewExportDataStmtAction(query, formattedQuery, params, queryArgs, outputColumns, resolved), nil
 }
 
-// readExportDataOptions extracts the string-valued options off a
-// ResolvedOption list. The option's value is read directly from its
-// resolved literal — no SQL re-format / unquote dance — so escapes and
-// quoting handled by the analyzer are honoured by construction.
+// ResolvedExportDataOptions is the parsed, type-checked, and
+// format-validated form of an EXPORT DATA OPTIONS(...) clause. The fields
+// flow into ExportDataStmtAction.
+type ResolvedExportDataOptions struct {
+	URI         string
+	Format      exportdata.Format
+	Compression exportdata.Compression
+	Overwrite   bool
+	CSV         exportdata.CSVOptions
+}
+
+// readExportDataOptions parses every option off the resolved OPTIONS
+// list, type-checks it against the option's expected value kind, and
+// validates format-specific combinations (the CSV-only options must not
+// be supplied with a non-CSV format, etc.). Unknown options are a hard
+// error rather than a silent drop — letting an unimplemented option pass
+// through silently would produce output the caller did not ask for with
+// no signal that the option had no effect.
 //
-// Every option in the list must be one the engine actually honours
-// (today, just `uri` and `format`) and must be a readable string literal.
-// Real BigQuery rejects unknown / unreadable OPTIONS at analysis time;
-// silently dropping them here would let a `header = true`,
-// `compression = 'GZIP'`, or `overwrite = true` pass through and produce
-// output the caller did not ask for, with no signal that the option had
-// no effect. The error names the offending option so it is obvious what
-// to remove or, when implemented later, what new behaviour was wired up.
-func readExportDataOptions(_ context.Context, opts []*googlesql.ResolvedOption) (uri string, format string, err error) {
+// Every value is read directly from its resolved literal (no SQL re-format
+// / unquote dance) so escapes and quoting handled by the analyzer are
+// honoured by construction; non-literal expressions (e.g.
+// `uri = CONCAT(...)`) are rejected with a message that names the option,
+// avoiding the misdiagnosis where a stripped value would later surface as
+// "required option `uri` is missing".
+func readExportDataOptions(opts []*googlesql.ResolvedOption) (*ResolvedExportDataOptions, error) {
+	out := &ResolvedExportDataOptions{}
+	var (
+		formatStr    string
+		compressStr  string
+		headerSet    bool
+		headerValue  bool
+		uriSet       bool
+	)
 	for _, opt := range opts {
 		name, _ := opt.Name()
 		key := strings.ToLower(name)
-		if key != "uri" && key != "format" {
-			return "", "", fmt.Errorf("EXPORT DATA: option %q is not supported by googlesqlite", name)
-		}
-		val, ok, verr := exportDataStringLiteralOption(opt)
-		if verr != nil {
-			return "", "", fmt.Errorf("EXPORT DATA: read option %q: %w", name, verr)
-		}
-		if !ok {
-			return "", "", fmt.Errorf("EXPORT DATA: option %q must be a string literal", name)
-		}
 		switch key {
-		case "uri":
-			uri = val
-		case "format":
-			format = val
+		case "uri", "format", "compression", "field_delimiter":
+			val, err := readExportDataStringOption(opt)
+			if err != nil {
+				return nil, err
+			}
+			switch key {
+			case "uri":
+				out.URI = val
+				uriSet = true
+			case "format":
+				formatStr = val
+			case "compression":
+				compressStr = val
+			case "field_delimiter":
+				out.CSV.FieldDelimiter = val
+			}
+		case "overwrite":
+			b, err := readExportDataBoolOption(opt)
+			if err != nil {
+				return nil, err
+			}
+			out.Overwrite = b
+		case "header":
+			b, err := readExportDataBoolOption(opt)
+			if err != nil {
+				return nil, err
+			}
+			headerSet = true
+			headerValue = b
+		case "use_avro_logical_types":
+			// `use_avro_logical_types` is a real BigQuery option but only
+			// meaningful for `format = 'AVRO'`, which the encoder does
+			// not implement. Type-check the value so misuse (e.g.
+			// `use_avro_logical_types = 'yes'`) is reported as an option
+			// type error rather than a vague "format AVRO is not
+			// supported" downstream, then surface the format gap.
+			if _, err := readExportDataBoolOption(opt); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("EXPORT DATA: option `use_avro_logical_types` is only valid with format = 'AVRO', which is not yet supported by googlesqlite")
+		default:
+			return nil, fmt.Errorf("EXPORT DATA: option %q is not supported by googlesqlite", name)
 		}
 	}
-	return uri, format, nil
+
+	if !uriSet || out.URI == "" {
+		return nil, fmt.Errorf("EXPORT DATA: required option `uri` is missing")
+	}
+
+	format, err := exportdata.ParseFormat(formatStr)
+	if err != nil {
+		return nil, err
+	}
+	out.Format = format
+
+	compression, err := exportdata.ParseCompression(compressStr, format)
+	if err != nil {
+		return nil, err
+	}
+	out.Compression = compression
+
+	// Format-compatibility checks for CSV-only options. Real BigQuery
+	// rejects `header` / `field_delimiter` outside of format = 'CSV';
+	// dropping them silently would mean the JSON output looked fine but
+	// the caller's intent was discarded.
+	if headerSet {
+		if format != exportdata.FormatCSV {
+			return nil, fmt.Errorf("EXPORT DATA: option `header` is only valid with format = 'CSV'")
+		}
+		out.CSV.Header = &headerValue
+	}
+	if out.CSV.FieldDelimiter != "" && format != exportdata.FormatCSV {
+		return nil, fmt.Errorf("EXPORT DATA: option `field_delimiter` is only valid with format = 'CSV'")
+	}
+	return out, nil
 }
 
-// exportDataStringLiteralOption reads a string value from a ResolvedOption
-// whose value is a ResolvedLiteral of STRING type. Returns (value, true,
-// nil) on success, (_, false, nil) when the option's value is not a string
-// literal (an expression, a non-string literal, ...), or an error if the
-// underlying value extraction fails.
-func exportDataStringLiteralOption(opt *googlesql.ResolvedOption) (string, bool, error) {
+// readExportDataStringOption reads a STRING-typed literal value off an
+// option. Non-literal or non-string values are rejected with an error
+// naming the option, so the caller does not silently lose a value they
+// supplied (and is not misled into "required option missing" downstream).
+func readExportDataStringOption(opt *googlesql.ResolvedOption) (string, error) {
+	name, _ := opt.Name()
 	expr, _ := opt.Value()
 	lit, ok := expr.(*googlesql.ResolvedLiteral)
 	if !ok {
-		return "", false, nil
+		return "", fmt.Errorf("EXPORT DATA: option %q must be a string literal", name)
 	}
 	v, err := lit.Value()
 	if err != nil {
-		return "", false, err
+		return "", fmt.Errorf("EXPORT DATA: read option %q: %w", name, err)
 	}
 	kind, err := v.TypeKind()
 	if err != nil {
-		return "", false, err
+		return "", fmt.Errorf("EXPORT DATA: read option %q: %w", name, err)
 	}
 	if kind != googlesql.TypeKindTypeString {
-		return "", false, nil
+		return "", fmt.Errorf("EXPORT DATA: option %q must be a string literal", name)
 	}
 	s, err := v.StringValue()
 	if err != nil {
-		return "", false, err
+		return "", fmt.Errorf("EXPORT DATA: read option %q: %w", name, err)
 	}
-	return s, true, nil
+	return s, nil
+}
+
+// readExportDataBoolOption reads a BOOL-typed literal value off an option.
+func readExportDataBoolOption(opt *googlesql.ResolvedOption) (bool, error) {
+	name, _ := opt.Name()
+	expr, _ := opt.Value()
+	lit, ok := expr.(*googlesql.ResolvedLiteral)
+	if !ok {
+		return false, fmt.Errorf("EXPORT DATA: option %q must be a boolean literal", name)
+	}
+	v, err := lit.Value()
+	if err != nil {
+		return false, fmt.Errorf("EXPORT DATA: read option %q: %w", name, err)
+	}
+	kind, err := v.TypeKind()
+	if err != nil {
+		return false, fmt.Errorf("EXPORT DATA: read option %q: %w", name, err)
+	}
+	if kind != googlesql.TypeKindTypeBool {
+		return false, fmt.Errorf("EXPORT DATA: option %q must be a boolean literal", name)
+	}
+	b, err := v.BoolValue()
+	if err != nil {
+		return false, fmt.Errorf("EXPORT DATA: read option %q: %w", name, err)
+	}
+	return b, nil
 }
 
 func (a *Analyzer) newBeginStmtAction(ctx context.Context, query string, args []driver.NamedValue, node googlesql.ResolvedNode) (*BeginStmtAction, error) {

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -2416,11 +2416,11 @@ type ResolvedExportDataOptions struct {
 func readExportDataOptions(opts []*googlesql.ResolvedOption) (*ResolvedExportDataOptions, error) {
 	out := &ResolvedExportDataOptions{}
 	var (
-		formatStr    string
-		compressStr  string
-		headerSet    bool
-		headerValue  bool
-		uriSet       bool
+		formatStr   string
+		compressStr string
+		headerSet   bool
+		headerValue bool
+		uriSet      bool
 	)
 	for _, opt := range opts {
 		name, _ := opt.Name()

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -2466,6 +2466,27 @@ func readExportDataOptions(opts []*googlesql.ResolvedOption) (*ResolvedExportDat
 				return nil, err
 			}
 			return nil, fmt.Errorf("EXPORT DATA: option `use_avro_logical_types` is only valid with format = 'AVRO', which is not yet supported by googlesqlite")
+		case "spanner_options", "bigtable_options", "alloydb_options":
+			// Reverse-ETL destination options. Each is documented as a
+			// JSON-encoded STRING that configures the target connector
+			// (`spanner_options` → Cloud Spanner table/priority/tag,
+			// `bigtable_options` → Bigtable column families, etc.).
+			// Type-check the value as a string literal so a misuse like
+			// `spanner_options = 42` is reported as an option type error
+			// (naming the option) rather than collapsing into the
+			// downstream "format CLOUD_SPANNER not supported" message,
+			// then surface the destination gap with the option named.
+			if _, err := readExportDataStringOption(opt); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("EXPORT DATA: option `%s` targets a reverse-ETL destination (Cloud Spanner / Bigtable / AlloyDB) that is not supported by googlesqlite", key)
+		case "auto_create_column_families":
+			// Bigtable-only BOOL. Same shape as use_avro_logical_types:
+			// type-check first, then point at the missing destination.
+			if _, err := readExportDataBoolOption(opt); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("EXPORT DATA: option `auto_create_column_families` is only valid with format = 'CLOUD_BIGTABLE', which is not supported by googlesqlite")
 		default:
 			return nil, fmt.Errorf("EXPORT DATA: option %q is not supported by googlesqlite", name)
 		}

--- a/internal/exportdata/compression.go
+++ b/internal/exportdata/compression.go
@@ -1,0 +1,73 @@
+package exportdata
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Compression identifies the EXPORT DATA `compression` option value applied
+// on top of the format encoder.
+type Compression string
+
+const (
+	CompressionNone Compression = "NONE"
+	CompressionGZIP Compression = "GZIP"
+)
+
+// ParseCompression normalizes the `compression` option value against the
+// chosen format. An empty string maps to NONE. Real BigQuery only documents
+// NONE and GZIP for CSV / JSON exports; the format-incompatible codecs
+// (SNAPPY / DEFLATE / ZSTD / LZ4 are AVRO- or PARQUET-only) and unknown
+// values surface as a descriptive error rather than silently writing
+// uncompressed bytes.
+func ParseCompression(s string, format Format) (Compression, error) {
+	c := Compression(strings.ToUpper(strings.TrimSpace(s)))
+	if c == "" {
+		c = CompressionNone
+	}
+	switch c {
+	case CompressionNone:
+		return CompressionNone, nil
+	case CompressionGZIP:
+		switch format {
+		case FormatCSV, FormatNDJSON:
+			return CompressionGZIP, nil
+		}
+		return "", fmt.Errorf("EXPORT DATA: compression GZIP is not valid for format %s", format)
+	case "SNAPPY", "DEFLATE", "ZSTD", "LZ4":
+		return "", fmt.Errorf("EXPORT DATA: compression %s is not supported by googlesqlite", c)
+	default:
+		return "", fmt.Errorf("EXPORT DATA: unknown compression %q", s)
+	}
+}
+
+// WrapCompressor wraps the destination writer in the requested codec. The
+// returned WriteCloser must be Closed before the underlying writer is
+// closed so the compressed stream is flushed in full.
+func WrapCompressor(w io.WriteCloser, c Compression) (io.WriteCloser, error) {
+	switch c {
+	case CompressionNone, "":
+		return w, nil
+	case CompressionGZIP:
+		return &gzipWriteCloser{Writer: gzip.NewWriter(w), underlying: w}, nil
+	}
+	return nil, fmt.Errorf("EXPORT DATA: unsupported compression %q", c)
+}
+
+// gzipWriteCloser closes both the gzip writer (flushing the trailer) and
+// the underlying destination so callers only need to defer one Close.
+type gzipWriteCloser struct {
+	*gzip.Writer
+	underlying io.WriteCloser
+}
+
+func (w *gzipWriteCloser) Close() error {
+	gerr := w.Writer.Close()
+	uerr := w.underlying.Close()
+	if gerr != nil {
+		return gerr
+	}
+	return uerr
+}

--- a/internal/exportdata/exportdata.go
+++ b/internal/exportdata/exportdata.go
@@ -1,11 +1,11 @@
 // Package exportdata holds the EXPORT DATA execution machinery: the URI
-// writer registry, built-in writers (gs://), and the format encoders the
-// driver uses to materialize an `EXPORT DATA OPTIONS(...) AS SELECT ...`
-// statement to its destination.
+// writer registry, built-in writers (gs://), the format encoders and the
+// compression wrappers the driver uses to materialize an
+// `EXPORT DATA OPTIONS(...) AS SELECT ...` statement to its destination.
 //
-// The public API surface — the URIWriter type and RegisterURIWriter — is
-// re-exported from the root googlesqlite package so callers do not need to
-// import internal/ paths.
+// The public API surface — the URIWriter / WriterOpts types and
+// RegisterURIWriter — is re-exported from the root googlesqlite package so
+// callers do not need to import internal/ paths.
 package exportdata
 
 import (
@@ -15,12 +15,24 @@ import (
 	"sync"
 )
 
+// WriterOpts carries scheme-independent EXPORT DATA OPTIONS that influence
+// how the destination is opened. URIWriter implementations should honor
+// each field where it is meaningful for their scheme and ignore the rest.
+type WriterOpts struct {
+	// Overwrite controls what happens when the destination already
+	// exists. The BigQuery default is false (the statement fails when
+	// the destination is present); set true to replace any existing
+	// object atomically.
+	Overwrite bool
+}
+
 // URIWriter opens an io.WriteCloser for an EXPORT DATA destination URI.
-// Implementations should honor the URI's scheme and resolve any
+// Implementations should honor the URI's scheme, resolve any
 // environment-driven host overrides (e.g. STORAGE_EMULATOR_HOST for gs://)
-// themselves. Closing the returned writer is the caller's responsibility and
-// is what commits the bytes — the contract follows io.WriteCloser semantics.
-type URIWriter func(ctx context.Context, uri string) (io.WriteCloser, error)
+// themselves, and apply the WriterOpts fields meaningful to that scheme.
+// Closing the returned writer is the caller's responsibility and is what
+// commits the bytes — the contract follows io.WriteCloser semantics.
+type URIWriter func(ctx context.Context, uri string, opts WriterOpts) (io.WriteCloser, error)
 
 var (
 	writersMu sync.RWMutex

--- a/internal/exportdata/format.go
+++ b/internal/exportdata/format.go
@@ -19,9 +19,16 @@ const (
 
 // ParseFormat normalizes the `format` option value. An empty string maps to
 // CSV (matching real BigQuery's default). Formats that BigQuery accepts but
-// the emulator does not yet implement (AVRO, PARQUET) return a descriptive
-// error rather than silently falling back, so callers see the gap instead
-// of a corrupt file.
+// the emulator does not yet implement fall into two buckets:
+//
+//   - Object-store formats (AVRO, PARQUET) — the encoder is missing.
+//   - Reverse-ETL destination formats (CLOUD_SPANNER, CLOUD_BIGTABLE,
+//     CLOUD_PUBSUB, ALLOYDB) — these target operational databases /
+//     pub-sub topics rather than blob storage and require a managed
+//     destination connector that googlesqlite does not provide.
+//
+// Both buckets return a descriptive error naming the format so callers see
+// the gap instead of a corrupt file or a generic "unknown format".
 func ParseFormat(s string) (Format, error) {
 	switch strings.ToUpper(strings.TrimSpace(s)) {
 	case "", "CSV":
@@ -30,6 +37,8 @@ func ParseFormat(s string) (Format, error) {
 		return FormatNDJSON, nil
 	case "AVRO", "PARQUET":
 		return "", fmt.Errorf("EXPORT DATA: format %q is not yet supported by googlesqlite", s)
+	case "CLOUD_SPANNER", "CLOUD_BIGTABLE", "CLOUD_PUBSUB", "ALLOYDB":
+		return "", fmt.Errorf("EXPORT DATA: reverse-ETL destination format %q is not supported by googlesqlite (no managed connector for the target service)", s)
 	default:
 		return "", fmt.Errorf("EXPORT DATA: unknown format %q", s)
 	}

--- a/internal/exportdata/format.go
+++ b/internal/exportdata/format.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 )
 
 // Format is the EXPORT DATA output format selected by the `format` option.
@@ -34,6 +35,18 @@ func ParseFormat(s string) (Format, error) {
 	}
 }
 
+// CSVOptions carries the CSV-specific EXPORT DATA options. The zero value
+// is a sentinel: Header defaults to true at encode time when nil, matching
+// BigQuery, and FieldDelimiter defaults to ",".
+type CSVOptions struct {
+	// Header writes a header row of column names when true. nil leaves
+	// the default (true) in place; *false explicitly suppresses it.
+	Header *bool
+	// FieldDelimiter is the single-character cell separator. Empty
+	// defaults to ",". Strings longer than one rune are rejected.
+	FieldDelimiter string
+}
+
 // RowSource yields successive rows of an EXPORT DATA output. Each call must
 // return the next row's values in the order matching the column list passed
 // to EncodeRows. The bool result is true while more rows remain and false
@@ -43,20 +56,33 @@ type RowSource func() (values []any, hasMore bool, err error)
 // EncodeRows streams rows from src into w using the chosen format. CSV
 // writes a header row of column names; NDJSON writes one JSON object per
 // row keyed by column name.
-func EncodeRows(w io.Writer, format Format, columns []string, src RowSource) error {
+func EncodeRows(w io.Writer, format Format, columns []string, csvOpts CSVOptions, src RowSource) error {
 	switch format {
 	case FormatCSV:
-		return encodeCSV(w, columns, src)
+		return encodeCSV(w, columns, csvOpts, src)
 	case FormatNDJSON:
 		return encodeNDJSON(w, columns, src)
 	}
 	return fmt.Errorf("EXPORT DATA: unsupported format %q", format)
 }
 
-func encodeCSV(w io.Writer, columns []string, src RowSource) error {
+func encodeCSV(w io.Writer, columns []string, opts CSVOptions, src RowSource) error {
 	cw := csv.NewWriter(w)
-	if err := cw.Write(columns); err != nil {
-		return fmt.Errorf("EXPORT DATA: write CSV header: %w", err)
+	if delim := opts.FieldDelimiter; delim != "" {
+		r, size := utf8.DecodeRuneInString(delim)
+		if r == utf8.RuneError || size != len(delim) {
+			return fmt.Errorf("EXPORT DATA: field_delimiter must be a single rune, got %q", delim)
+		}
+		cw.Comma = r
+	}
+	writeHeader := true
+	if opts.Header != nil {
+		writeHeader = *opts.Header
+	}
+	if writeHeader {
+		if err := cw.Write(columns); err != nil {
+			return fmt.Errorf("EXPORT DATA: write CSV header: %w", err)
+		}
 	}
 	for {
 		values, hasMore, err := src()

--- a/internal/exportdata/gcs.go
+++ b/internal/exportdata/gcs.go
@@ -31,7 +31,12 @@ func init() {
 // can produce many objects, one per shard) is collapsed to the 12-digit
 // shard identifier BigQuery uses for the first shard, so a one-shard write
 // against `gs://b/out/*.csv` lands at `gs://b/out/000000000000.csv`.
-func openGCSWriter(ctx context.Context, uri string) (io.WriteCloser, error) {
+//
+// WriterOpts.Overwrite=false (the BigQuery default) is enforced by a
+// DoesNotExist precondition on the object; the write fails with HTTP 412
+// PreconditionFailed if the object already exists. Overwrite=true skips the
+// precondition so the object is replaced unconditionally.
+func openGCSWriter(ctx context.Context, uri string, opts WriterOpts) (io.WriteCloser, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("exportdata: parse gs:// URI %q: %w", uri, err)
@@ -49,15 +54,23 @@ func openGCSWriter(ctx context.Context, uri string) (io.WriteCloser, error) {
 	// shard identifier BigQuery uses for the first shard.
 	object = strings.ReplaceAll(object, "*", "000000000000")
 
-	var opts []option.ClientOption
+	var clientOpts []option.ClientOption
 	if host := os.Getenv("STORAGE_EMULATOR_HOST"); host != "" {
-		opts = append(opts, option.WithEndpoint(host), option.WithoutAuthentication())
+		clientOpts = append(clientOpts, option.WithEndpoint(host), option.WithoutAuthentication())
 	}
-	client, err := storage.NewClient(ctx, opts...)
+	client, err := storage.NewClient(ctx, clientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("exportdata: open GCS client: %w", err)
 	}
-	w := client.Bucket(bucket).Object(object).NewWriter(ctx)
+	obj := client.Bucket(bucket).Object(object)
+	if !opts.Overwrite {
+		// DoesNotExist makes the write atomic against concurrent
+		// creators and matches BigQuery's `overwrite = false` default
+		// (the statement must fail when the destination already exists
+		// instead of silently clobbering it).
+		obj = obj.If(storage.Conditions{DoesNotExist: true})
+	}
+	w := obj.NewWriter(ctx)
 	return &gcsObjectWriter{Writer: w, client: client}, nil
 }
 

--- a/internal/stmt_action.go
+++ b/internal/stmt_action.go
@@ -484,23 +484,24 @@ func (a *QueryStmtAction) Cleanup(ctx context.Context, conn *Conn) error {
 }
 
 // ExportDataStmtAction materializes the rows of an
-// `EXPORT DATA OPTIONS(uri = '...', format = '...') AS <query>` statement
-// to the destination URI. The inner query is run through the standard
-// QueryStmtAction code path; the rows it produces are streamed through the
-// format encoder into a writer obtained from the URI's registered scheme
-// (see exportdata.RegisterURIWriter — `gs://` is registered by default).
+// `EXPORT DATA OPTIONS(...) AS <query>` statement to the destination URI.
+// The inner query is run through the standard QueryStmtAction code path;
+// the rows it produces are streamed through the format encoder, an
+// optional compression wrapper and the writer obtained from the URI's
+// registered scheme (see exportdata.RegisterURIWriter — `gs://` is
+// registered by default).
 //
-// EXPORT DATA returns no rows to the caller — neither Exec nor Query yields
-// any — so the result is always an empty driver.Result / *Rows after the
-// destination object has been written. Real BigQuery has the same shape.
+// EXPORT DATA returns no rows to the caller — neither Exec nor Query
+// yields any — so the result is always an empty driver.Result / *Rows
+// after the destination object has been written. Real BigQuery has the
+// same shape.
 type ExportDataStmtAction struct {
 	query          string
 	params         []*googlesql.ResolvedParameter
 	args           []any
 	formattedQuery string
 	outputColumns  []*ColumnSpec
-	uri            string
-	format         exportdata.Format
+	opts           *ResolvedExportDataOptions
 }
 
 // NewExportDataStmtAction constructs the action from a parsed inner query
@@ -512,8 +513,7 @@ func NewExportDataStmtAction(
 	params []*googlesql.ResolvedParameter,
 	args []any,
 	outputColumns []*ColumnSpec,
-	uri string,
-	format exportdata.Format,
+	opts *ResolvedExportDataOptions,
 ) *ExportDataStmtAction {
 	return &ExportDataStmtAction{
 		query:          query,
@@ -521,8 +521,7 @@ func NewExportDataStmtAction(
 		args:           args,
 		formattedQuery: formattedQuery,
 		outputColumns:  outputColumns,
-		uri:            uri,
-		format:         format,
+		opts:           opts,
 	}
 }
 
@@ -556,17 +555,19 @@ func (a *ExportDataStmtAction) Args() []any { return nil }
 
 func (a *ExportDataStmtAction) Cleanup(ctx context.Context, conn *Conn) error { return nil }
 
-// export resolves the URI's scheme writer, opens the destination, runs the
-// inner query, and streams each row through the format encoder. The writer
-// is closed before the function returns — that is where the bytes commit
-// for stores like GCS.
+// export resolves the URI's scheme writer, opens the destination
+// (honouring `overwrite`), runs the inner query, wraps the writer in the
+// requested compression codec, and streams each row through the format
+// encoder. Every wrapper is closed in reverse order before the function
+// returns — that is where the bytes commit for stores like GCS, and where
+// the compression trailer is flushed.
 func (a *ExportDataStmtAction) export(ctx context.Context, conn *Conn) error {
-	u, err := url.Parse(a.uri)
+	u, err := url.Parse(a.opts.URI)
 	if err != nil {
-		return fmt.Errorf("EXPORT DATA: invalid uri %q: %w", a.uri, err)
+		return fmt.Errorf("EXPORT DATA: invalid uri %q: %w", a.opts.URI, err)
 	}
 	if u.Scheme == "" {
-		return fmt.Errorf("EXPORT DATA: uri %q has no scheme", a.uri)
+		return fmt.Errorf("EXPORT DATA: uri %q has no scheme", a.opts.URI)
 	}
 	writer := exportdata.LookupURIWriter(u.Scheme)
 	if writer == nil {
@@ -594,13 +595,20 @@ func (a *ExportDataStmtAction) export(ctx context.Context, conn *Conn) error {
 		}
 	}
 
-	wc, err := writer(ctx, a.uri)
+	dest, err := writer(ctx, a.opts.URI, exportdata.WriterOpts{Overwrite: a.opts.Overwrite})
 	if err != nil {
-		return fmt.Errorf("EXPORT DATA: open destination %q: %w", a.uri, err)
+		return fmt.Errorf("EXPORT DATA: open destination %q: %w", a.opts.URI, err)
 	}
-	encodeErr := exportdata.EncodeRows(wc, a.format, columns, sqlRowsSource(rows, len(columns)))
-	if closeErr := wc.Close(); closeErr != nil && encodeErr == nil {
-		encodeErr = fmt.Errorf("EXPORT DATA: close destination %q: %w", a.uri, closeErr)
+	// Wrap with the compression codec; both Closers must run so the
+	// compression trailer flushes AND the underlying object commits.
+	encStream, err := exportdata.WrapCompressor(dest, a.opts.Compression)
+	if err != nil {
+		_ = dest.Close()
+		return err
+	}
+	encodeErr := exportdata.EncodeRows(encStream, a.opts.Format, columns, a.opts.CSV, sqlRowsSource(rows, len(columns)))
+	if closeErr := encStream.Close(); closeErr != nil && encodeErr == nil {
+		encodeErr = fmt.Errorf("EXPORT DATA: close destination %q: %w", a.opts.URI, closeErr)
 	}
 	return encodeErr
 }

--- a/main_test.go
+++ b/main_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	// captured bytes register their own scheme via registerMemScheme(t)
 	// (see export_data_test.go) — that helper picks a per-test scheme so
 	// concurrent tests do not contend on a shared map.
-	googlesqlite.RegisterExportURIWriter("mem", func(_ context.Context, _ string) (io.WriteCloser, error) {
+	googlesqlite.RegisterExportURIWriter("mem", func(_ context.Context, _ string, _ googlesqlite.ExportWriterOpts) (io.WriteCloser, error) {
 		return nopWriteCloser{}, nil
 	})
 


### PR DESCRIPTION
## Why

The initial EXPORT DATA landing (#13) only honored `uri` and `format`. The other documented options were silently dropped, which let SQL like

```sql
EXPORT DATA OPTIONS(
  uri              = 'gs://bucket/out.csv.gz',
  format           = 'CSV',
  compression      = 'GZIP',
  header           = false,
  field_delimiter  = '|',
  overwrite        = true
) AS SELECT * FROM t;
```

parse and run, but emit uncompressed bytes with a default header row and a comma delimiter to a destination that might already contain data — the worst possible failure mode for an export, since the caller has no signal that their intent was lost.

This PR closes the OPTIONS coverage gap and tightens the surrounding validation so unknown or mis-shaped input fails at parse time rather than producing the wrong bytes.

## Options plumbed end-to-end

| Option | Type | Notes |
| --- | --- | --- |
| `compression` | STRING | NONE / GZIP honored for CSV and JSON. SNAPPY / DEFLATE / ZSTD / LZ4 are named and rejected per-format (they are AVRO- / PARQUET-only in real BigQuery, neither of which we encode yet). |
| `header` | BOOL | CSV only, default true. Using it with a non-CSV format errors with the option named. |
| `field_delimiter` | STRING | CSV only. Validated as a single rune via `utf8.DecodeRuneInString`. Using it with a non-CSV format errors with the option named. |
| `overwrite` | BOOL | Threaded through a new `ExportWriterOpts` struct passed to every `URIWriter`. The built-in `gs://` writer turns this into a `storage.Conditions{DoesNotExist: true}` precondition so EXPORT DATA against an existing object fails fast (matching the GCS behaviour) instead of silently overwriting. |
| `use_avro_logical_types` | BOOL | Type-checked, then rejected with a message naming both the option and the missing AVRO format support so callers know their input was understood and which gap to file. |

## Statement-level features

- **`WITH CONNECTION <name>`** (Omni `s3://` / `azure://`) is now rejected explicitly instead of silently dropped. Silent passthrough would route the export through whatever the registered URIWriter picks by default, dropping the caller's credential binding. The diagnostic points at the scheme-registry escape hatch.
- **`IsValueTable`** (`SELECT AS STRUCT` / `AS VALUE`) is intentionally **not** rejected: real BigQuery accepts these for EXPORT DATA, and our column-oriented encoders see the struct's fields via `OutputColumnList` so they produce the same per-row shape. Any encoder-specific gap (e.g. top-level ARRAY in CSV) is left to the format encoder, matching how real BigQuery rejects nested data in CSV.

## Validation tightened

- Every option value is read directly from its resolved literal via `ResolvedLiteral.Value().StringValue()` / `BoolValue()` with a type check, so non-literal expressions like `uri = CONCAT(...)` fail with `option \`uri\` must be a string literal` instead of being stripped and re-surfacing downstream as the misleading `required option \`uri\` is missing`.
- Unknown option names are a hard error (was: silently ignored). The message names the offending option so the caller sees exactly what was rejected.

## Tests

- `TestExportDataErrorPaths`: 5 → 10 subtests. Adds coverage for `header` / `field_delimiter` outside CSV, incompatible compression, `use_avro_logical_types`, and `WITH CONNECTION`. The helper closes any non-nil rows defensively — without this, a regression where a previously-rejected statement starts silently succeeding (exactly what bit the original landing: `overwrite = false` was used as the "unknown option" stand-in and started succeeding once `overwrite` became valid) would pin the connection and turn the failure into a multi-minute `conn.Close()` deadlock instead of a crisp assertion.
- `TestExportDataMemRoundTrip`: 1 → 6 subtests. Covers default CSV, `header = false`, `field_delimiter = '|'`, `compression = 'GZIP'`, NDJSON, and JSON + GZIP. The gzip cases gunzip the captured bytes back so the test fails if the wrapper is bypassed.
- `TestExportDataOverwriteOption` (new): registers a writer that refuses to re-open the same key without `opts.Overwrite = true` and exercises both directions, catching a silent flip of the option between the analyzer and the writer.
- The mem writer is now registered per-test via `registerMemScheme(t)` with a unique scheme derived from `t.Name()` (sanitized to the RFC 3986 scheme charset) and a local capture map, so tests do not contend on any package-global state.

## Test runs

- `go test -run '^TestExportData' -count=1` — all 17 cases pass
- `go test -race -run '^TestExportData' -count=1` — all 17 cases pass
- `go test -count=1 ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)