### PR TITLE
Implement driver.Validator on Conn so the pool drops poisoned connections

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -346,7 +347,70 @@ type Conn struct {
 	systemVars     map[string]string
 	scriptVars     map[string]string
 	materializeCTE bool
+
+	// dead is set when an operation on this Conn observes that the
+	// inner *sql.Conn has been closed (sql.ErrConnDone). database/sql
+	// pools Conn values across requests; without an explicit signal it
+	// happily hands a Conn whose inner handle has been closed by a
+	// cancelled tx's discardConn rollback to the next caller, which
+	// then surfaces a confusing "sql: connection is already closed"
+	// 500 on every subsequent request (see IsValid and the
+	// translateConnDone defers below). The dead flag is read by IsValid
+	// and written from any goroutine that drove the failing operation;
+	// concurrent writes are harmless because they all store the same
+	// value (true).
+	dead atomic.Bool
 }
+
+// IsValid implements database/sql/driver.Validator. database/sql calls
+// it on every pool fetch before handing the Conn to the next caller —
+// returning false makes the pool discard us and pull a fresh one
+// instead of letting us surface a confusing "sql: connection is
+// already closed" error inside the next request. The flag is set by
+// translateConnDone whenever an earlier operation observed the inner
+// handle had been closed (typically by a request whose context was
+// cancelled mid-statement; database/sql's tx watcher then ran
+// Rollback(discardConn=true) on the inner connection).
+func (c *Conn) IsValid() bool {
+	return !c.dead.Load()
+}
+
+// translateConnDone is the single point that converts the inner
+// "connection is closed" sentinel into the driver-level "drop me"
+// sentinel.
+//
+// The inner *sql.Conn we hold can become done while still appearing
+// healthy to database/sql's outer pool: a cancelled request triggers
+// the inner-tx watcher's Rollback(discardConn=true), which closes the
+// inner conn, but the outer pool doesn't know because the failure
+// hasn't surfaced yet. The first operation on the poisoned Conn then
+// fails with sql.ErrConnDone — which to a caller looks like a server
+// error, not a transient retryable condition. Mapping it to
+// driver.ErrBadConn tells database/sql to drop the Conn from the pool
+// and retry on a fresh one (when the call has not yet sent data),
+// hiding the transient from the caller; setting dead=true means the
+// next IsValid call returns false so the Conn never even gets that
+// far again.
+//
+// Wrapped errors are inspected because ExecContext / QueryContext may
+// fold cleanup-time errors into an internal.ErrorGroup; the group
+// implements Unwrap() []error so errors.Is reaches the sentinel.
+func (c *Conn) translateConnDone(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sql.ErrConnDone) {
+		c.dead.Store(true)
+		return driver.ErrBadConn
+	}
+	return err
+}
+
+// Static contract check: database/sql's pool only calls IsValid via a
+// type assertion against driver.Validator. Failing this assertion at
+// compile time keeps a future refactor that drops the method visible
+// instead of silently regressing the #478 fix.
+var _ driver.Validator = (*Conn)(nil)
 
 func newConn(db *sql.DB, catalog *internal.Catalog) (*Conn, error) {
 	conn, err := db.Conn(context.Background())
@@ -419,6 +483,7 @@ func recoverPanicAsError(e *error) {
 }
 
 func (c *Conn) PrepareContext(ctx context.Context, query string) (s driver.Stmt, e error) {
+	defer func() { e = c.translateConnDone(e) }()
 	defer recoverPanicAsError(&e)
 	conn := internal.NewConnWithOptions(c.conn, c.tx, c.systemVars, c.scriptVars, c.materializeCTE)
 	actionFuncs, err := c.analyzer.Analyze(ctx, conn, query, nil)
@@ -441,6 +506,7 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (s driver.Stmt,
 }
 
 func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (r driver.Result, e error) {
+	defer func() { e = c.translateConnDone(e) }()
 	defer recoverPanicAsError(&e)
 	conn := internal.NewConnWithOptions(c.conn, c.tx, c.systemVars, c.scriptVars, c.materializeCTE)
 	actionFuncs, err := c.analyzer.Analyze(ctx, conn, query, args)
@@ -476,6 +542,7 @@ func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.Name
 }
 
 func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (r driver.Rows, e error) {
+	defer func() { e = c.translateConnDone(e) }()
 	defer recoverPanicAsError(&e)
 	conn := internal.NewConnWithOptions(c.conn, c.tx, c.systemVars, c.scriptVars, c.materializeCTE)
 	actionFuncs, err := c.analyzer.Analyze(ctx, conn, query, args)
@@ -514,7 +581,8 @@ func (c *Conn) Close() error {
 	return c.conn.Close()
 }
 
-func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (t driver.Tx, e error) {
+	defer func() { e = c.translateConnDone(e) }()
 	tx, err := c.conn.BeginTx(ctx, &sql.TxOptions{
 		Isolation: sql.IsolationLevel(opts.Isolation),
 		ReadOnly:  opts.ReadOnly,
@@ -529,7 +597,8 @@ func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 	}, nil
 }
 
-func (c *Conn) Begin() (driver.Tx, error) {
+func (c *Conn) Begin() (t driver.Tx, e error) {
+	defer func() { e = c.translateConnDone(e) }()
 	tx, err := c.conn.BeginTx(context.Background(), nil)
 	if err != nil {
 		return nil, err

--- a/internal/error.go
+++ b/internal/error.go
@@ -29,3 +29,12 @@ func (eg *ErrorGroup) Error() string {
 	}
 	return ""
 }
+
+// Unwrap exposes the wrapped errors so errors.Is / errors.As can
+// traverse them. Without this an ErrorGroup that happens to contain a
+// sentinel like sql.ErrConnDone or driver.ErrBadConn is opaque to
+// callers that use errors.Is for control flow — notably the driver's
+// dead-connection translation in driver.go.
+func (eg *ErrorGroup) Unwrap() []error {
+	return eg.errs
+}

--- a/validator_internal_test.go
+++ b/validator_internal_test.go
@@ -1,0 +1,114 @@
+package googlesqlite
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"testing"
+
+	internal "github.com/goccy/googlesqlite/internal"
+)
+
+// TestConn_IsValid_And_TranslateConnDone covers the two pieces
+// database/sql's pool relies on to drop a Conn whose inner *sql.Conn
+// was closed under us (typically by a cancelled transaction's
+// discardConn rollback): IsValid (cheap, called on every pool fetch)
+// and the translateConnDone helper that maps sql.ErrConnDone to
+// driver.ErrBadConn and flips the dead flag.
+//
+// Driving translateConnDone directly with the sentinel — rather than
+// trying to time a real cancellation — keeps this test deterministic;
+// the end-to-end behaviour is exercised by bigquery-emulator's
+// TestIssue478ConnectionCorruptionOnCancel, which depends on the same
+// translation working through database/sql's two-layer pool.
+func TestConn_IsValid_And_TranslateConnDone(t *testing.T) {
+	t.Run("fresh Conn is valid", func(t *testing.T) {
+		c := &Conn{}
+		if !c.IsValid() {
+			t.Fatal("a freshly-allocated Conn must report IsValid()=true; otherwise database/sql would never put us in the pool")
+		}
+	})
+
+	t.Run("nil error passes through and does not flip dead", func(t *testing.T) {
+		c := &Conn{}
+		if got := c.translateConnDone(nil); got != nil {
+			t.Fatalf("translateConnDone(nil) = %v; want nil", got)
+		}
+		if !c.IsValid() {
+			t.Fatal("Conn was marked dead after a nil error; the flag is only meant for the ErrConnDone path")
+		}
+	})
+
+	t.Run("unrelated error passes through and does not flip dead", func(t *testing.T) {
+		c := &Conn{}
+		sentinel := errors.New("boom")
+		if got := c.translateConnDone(sentinel); !errors.Is(got, sentinel) {
+			t.Fatalf("translateConnDone of an unrelated error mutated it: got %v", got)
+		}
+		if !c.IsValid() {
+			t.Fatal("Conn was marked dead after an unrelated error; only ErrConnDone may flip the flag")
+		}
+	})
+
+	t.Run("ErrConnDone is mapped to ErrBadConn and flips dead", func(t *testing.T) {
+		c := &Conn{}
+		out := c.translateConnDone(sql.ErrConnDone)
+		if !errors.Is(out, driver.ErrBadConn) {
+			t.Fatalf("translateConnDone(sql.ErrConnDone) = %v; want driver.ErrBadConn so database/sql discards-and-retries", out)
+		}
+		if c.IsValid() {
+			t.Fatal("Conn must be marked dead after observing ErrConnDone, so the next pool fetch is skipped via IsValid")
+		}
+	})
+
+	t.Run("wrapped ErrConnDone is mapped to ErrBadConn", func(t *testing.T) {
+		c := &Conn{}
+		wrapped := fmt.Errorf("upper-layer context: %w", sql.ErrConnDone)
+		out := c.translateConnDone(wrapped)
+		if !errors.Is(out, driver.ErrBadConn) {
+			t.Fatalf("translateConnDone(wrapped) = %v; want driver.ErrBadConn (errors.Is must traverse Unwrap)", out)
+		}
+		if c.IsValid() {
+			t.Fatal("Conn must be marked dead even when ErrConnDone arrives wrapped")
+		}
+	})
+
+	t.Run("ErrorGroup carrying ErrConnDone is mapped to ErrBadConn", func(t *testing.T) {
+		// ExecContext / QueryContext fold cleanup-time errors into an
+		// internal.ErrorGroup; the group's Unwrap() []error is what
+		// lets errors.Is reach the buried sentinel. Without that
+		// hookup the dead-conn signal would be silently lost when any
+		// cleanup error landed on the same path.
+		c := &Conn{}
+		eg := &internal.ErrorGroup{}
+		eg.Add(sql.ErrConnDone)
+		eg.Add(errors.New("cleanup also failed"))
+		out := c.translateConnDone(eg)
+		if !errors.Is(out, driver.ErrBadConn) {
+			t.Fatalf("translateConnDone(ErrorGroup) = %v; want driver.ErrBadConn (Unwrap() []error must surface the sentinel)", out)
+		}
+		if c.IsValid() {
+			t.Fatal("Conn must be marked dead when an ErrorGroup carries ErrConnDone")
+		}
+	})
+
+	t.Run("dead flag is sticky across translate calls", func(t *testing.T) {
+		c := &Conn{}
+		_ = c.translateConnDone(sql.ErrConnDone)
+		if c.IsValid() {
+			t.Fatal("setup: expected dead after first ErrConnDone")
+		}
+		// A subsequent benign error must not un-deaden us: once a Conn
+		// has been seen poisoned the flag stays set so the pool never
+		// hands it out again.
+		_ = c.translateConnDone(nil)
+		if c.IsValid() {
+			t.Fatal("Conn un-deadened after a nil translate; the flag must be sticky")
+		}
+		_ = c.translateConnDone(errors.New("unrelated"))
+		if c.IsValid() {
+			t.Fatal("Conn un-deadened after an unrelated translate; the flag must be sticky")
+		}
+	})
+}


### PR DESCRIPTION
## Why

A `Conn` whose inner `*sql.Conn` has been closed under it (typically by `database/sql`'s tx watcher running `Rollback(discardConn=true)` after the caller's request context was cancelled mid-statement) used to remain in the outer pool indistinguishable from a healthy one. The next caller that drew it from the pool then saw the inner handle's `sql: connection is already closed` surface as a server error instead of a transient — and clients that treat 500 as retryable would re-poll forever.

This is the underlying cause of [bigquery-emulator#478](https://github.com/goccy/bigquery-emulator/issues/478) ("Client library timeouts leads to 500 errors"). Verified locally: bigquery-emulator's `TestIssue478ConnectionCorruptionOnCancel` fails on `main` and passes when its `go.mod` points at this branch — no emulator-side code changes required.

## What the fix gives the pool

`database/sql`'s pool gives drivers two hooks to express "this conn is bad":

| Hook | When | Cost |
| --- | --- | --- |
| `driver.Validator.IsValid() bool` | called on every pool fetch | cheap, no I/O |
| `driver.ErrBadConn` returned from a driver method | discards and retries on a fresh conn | fallback when IsValid was true at fetch but the op observed the conn was dead |

This PR implements both:

- `Conn` gains a `dead atomic.Bool` flipped whenever any public method observes `sql.ErrConnDone` — directly, wrapped, or buried in an `internal.ErrorGroup`. `IsValid()` returns `!dead`, so the next fetch never even reaches a poisoned `Conn`.
- The translation is done in a single helper, `translateConnDone`, wired in via a `defer` on every entry point that touches `c.conn` or `c.tx` — `PrepareContext` / `ExecContext` / `QueryContext` / `BeginTx` / `Begin`. Adding a new entry point only requires one line.
- `internal.ErrorGroup` gets `Unwrap() []error` so `errors.Is` can traverse a group that wraps the sentinel; without it the dead-conn signal would be silently lost whenever a cleanup-time error landed on the same path.
- `var _ driver.Validator = (*Conn)(nil)` keeps a future refactor that drops the method visible at compile time.

## Why this layer

bigquery-emulator was about to ship its own middleware that swapped `r.Context()` for `context.WithoutCancel(...)` + a 5-minute safety timeout. That was treating a symptom — the proper invariant is "a `Conn` whose inner handle has been closed must not be reused" — and the place to enforce it is the driver's pool contract. Fixing it here lets every downstream user (not just the emulator) get the correct behaviour without touching its own code.

## Test

`validator_internal_test.go` drives `translateConnDone` directly with the sentinel:

```
=== RUN   TestConn_IsValid_And_TranslateConnDone
=== RUN   TestConn_IsValid_And_TranslateConnDone/fresh_Conn_is_valid
=== RUN   TestConn_IsValid_And_TranslateConnDone/nil_error_passes_through_and_does_not_flip_dead
=== RUN   TestConn_IsValid_And_TranslateConnDone/unrelated_error_passes_through_and_does_not_flip_dead
=== RUN   TestConn_IsValid_And_TranslateConnDone/ErrConnDone_is_mapped_to_ErrBadConn_and_flips_dead
=== RUN   TestConn_IsValid_And_TranslateConnDone/wrapped_ErrConnDone_is_mapped_to_ErrBadConn
=== RUN   TestConn_IsValid_And_TranslateConnDone/ErrorGroup_carrying_ErrConnDone_is_mapped_to_ErrBadConn
=== RUN   TestConn_IsValid_And_TranslateConnDone/dead_flag_is_sticky_across_translate_calls
--- PASS: TestConn_IsValid_And_TranslateConnDone (0.00s)
```

Determined deterministically — no real cancellation timing. End-to-end coverage lives on the bigquery-emulator side; that test reliably distinguishes fixed vs unfixed.

- `go test ./...` — full suite green (214s for the root package)
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
