### PR TITLE
fix: backtick-quote CTE name in WITH clause

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -2601,7 +2601,9 @@ func (n *RecursiveRefScanNode) FormatSQL(ctx context.Context) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("recursive ref scan rendered outside a recursive WITH entry")
 	}
-	return name, nil
+	// Quote to match the WITH definition (WithEntryNode) so names with
+	// hyphens and other non-bare-identifier characters resolve.
+	return fmt.Sprintf("`%s`", name), nil
 }
 
 // findRecursiveRefScanCols walks a scan tree looking for the column
@@ -2808,9 +2810,9 @@ func (n *WithEntryNode) FormatSQL(ctx context.Context) (string, error) {
 		for _, c := range canonical {
 			cols = append(cols, fmt.Sprintf("`%s`", uniqueColumnName(ctx, c)))
 		}
-		return fmt.Sprintf("%s(%s) AS%s ( %s )", queryName, strings.Join(cols, ","), hint, subquery), nil
+		return fmt.Sprintf("`%s`(%s) AS%s ( %s )", queryName, strings.Join(cols, ","), hint, subquery), nil
 	}
-	return fmt.Sprintf("%s AS%s ( %s )", queryName, hint, subquery), nil
+	return fmt.Sprintf("`%s` AS%s ( %s )", queryName, hint, subquery), nil
 }
 
 // cteMaterializeHint returns either " MATERIALIZED" (with a leading

--- a/regression_test.go
+++ b/regression_test.go
@@ -1425,6 +1425,39 @@ SELECT n FROM t ORDER BY n`)
 	}
 }
 
+// TestRegression_CTENameWithHyphen: a backtick-quoted CTE name containing a
+// hyphen (valid in BigQuery) was emitted unquoted by WithEntryNode, producing
+// `near "-": syntax error`. Covers plain and RECURSIVE CTEs. goccy/googlesqlite#17
+func TestRegression_CTENameWithHyphen(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("googlesqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	var x int64
+	if err := db.QueryRowContext(ctx,
+		"WITH `with-hyphen` AS (SELECT 1 AS x) SELECT x FROM `with-hyphen`",
+	).Scan(&x); err != nil {
+		t.Fatalf("non-recursive hyphenated CTE failed: %v", err)
+	}
+	if x != 1 {
+		t.Errorf("non-recursive: got %d want 1", x)
+	}
+
+	var total int64
+	if err := db.QueryRowContext(ctx,
+		"WITH RECURSIVE `rec-hyphen` AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM `rec-hyphen` WHERE n < 3) SELECT SUM(n) AS total FROM `rec-hyphen`",
+	).Scan(&total); err != nil {
+		t.Fatalf("recursive hyphenated CTE failed: %v", err)
+	}
+	if total != 6 {
+		t.Errorf("recursive: got %d want 6", total)
+	}
+}
+
 // TestRegression_DDLPartitionByAccepted: bqe#152
 func TestRegression_DDLPartitionByAccepted(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Problem

A CTE whose name contains a hyphen — a valid backtick-quoted identifier in BigQuery — fails with `near "-": syntax error`. `WithEntryNode.FormatSQL` emits the CTE name unquoted, so SQLite rejects the `WITH` definition. The reference side (`WithRefScanNode`) already backtick-quotes the name, so only the definition (and, for recursive CTEs, the self-reference) was bare.

```go
db, _ := sql.Open("googlesqlite", ":memory:")
db.Query("WITH `with-hyphen` AS (SELECT 1 AS x) SELECT x FROM `with-hyphen`")                       // near "-": syntax error
db.Query("WITH RECURSIVE `r-h` AS (SELECT 1 n UNION ALL SELECT n+1 FROM `r-h` WHERE n<3) SELECT SUM(n) FROM `r-h`") // same
```

Both queries run in real BigQuery, returning `1` and `6` respectively.

## Fix

Backtick-quote the CTE name at the three emitting sites — `WithEntryNode` (plain and `RECURSIVE` branches) and `RecursiveRefScanNode` — to match `WithRefScanNode`.

## Test

Adds `TestRegression_CTENameWithHyphen` to `regression_test.go` (next to the existing CTE/recursive-CTE tests), covering plain and `RECURSIVE` hyphenated CTE names (expected `1` and `6`, matching real BigQuery). Fails before the change with `near "-": syntax error`; passes after. Full suite (`go test .`) is green.

Closes #17
