### PR TITLE
Strip Go symbol table and DWARF from the Playground wasm

### DIFF
--- a/docs/playground/Makefile
+++ b/docs/playground/Makefile
@@ -19,9 +19,14 @@ build: build/wasm build/assets build/page
 # (cmd/googlesqlite, the `js && wasm` build) to public/googlesqlite.wasm
 # and copies the matching Go wasm_exec.js loader next to it. Everything
 # under public/ is a generated artifact and is gitignored.
+#
+# -ldflags "-s -w" strips the Go symbol table and DWARF info from the
+# engine wasm; the deployed Playground reads only the compiled bytes
+# and never touches them, and dropping them noticeably reduces the
+# size of both the served .gz and the wasm the browser decompresses.
 build/wasm:
 	mkdir -p $(PUBLIC)
-	cd $(ROOT) && GOOS=js GOARCH=wasm go build \
+	cd $(ROOT) && GOOS=js GOARCH=wasm go build -ldflags="-s -w" \
 	  -o docs/playground/$(WASM) ./cmd/googlesqlite
 	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" $(PUBLIC)/wasm_exec.js
 


### PR DESCRIPTION
## Summary
- `docs/playground/Makefile` `build/wasm`: pass `-ldflags="-s -w"` to `GOOS=js GOARCH=wasm go build` so the engine wasm ships without the Go symbol table / DWARF debug sections. The Playground only ever reads the compiled bytes, so the strip is invisible at runtime but visibly shrinks the served `.gz` and the wasm the browser decompresses.

That is the only change. No new CI tooling, no new Make targets, no swap setup.

## Why not wasm-opt
A Binaryen-based size optimisation was prototyped (`build/wasm/optimize` + `apt install binaryen` + a 16 GiB → 24 GiB swap on the runner) but turned out to be impractical for this engine on the stock `ubuntu-latest` runner: `cmd/googlesqlite` embeds the GoogleSQL analyzer wasm via `go:embed`, so `wasm-opt` ends up with a huge IR working set. Even at `-O3` with 24 GiB of swap the runner's working set blew past ~37 GiB and the GitHub Actions control plane killed the runner agent for being unresponsive. Newer Binaryen versions have memory-side improvements but the underlying size driver — the embedded analyzer — is not something a version bump fixes.

Shipping just `-s -w` keeps the release CI reliable and still gives a sizeable shrink. `wasm-opt` is worth revisiting once the analyzer is loaded separately (so it does not have to pass through `wasm-opt`'s IR).

## Test plan
- [ ] CI: Release test wasm job passes on this PR.
- [ ] Local: `cd docs/playground && make build/wasm` produces a `public/googlesqlite.wasm` smaller than `main`'s (no symbol table / DWARF).
- [ ] Local: `cd docs/playground && make dev` still loads and runs a representative GoogleSQL query in the browser.
