### PR TITLE
spanner: synchronise the sequenceCounters map

### DIFF
--- a/internal/functions/spanner/singletons.go
+++ b/internal/functions/spanner/singletons.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
+	"sync"
 	gotime "time"
 
 	"github.com/klauspost/compress/zstd"
@@ -266,7 +267,10 @@ func BindZstdDecompressToString(args ...value.Value) (value.Value, error) {
 // sequence. Spanner sequences are not yet modelled by googlesqlite —
 // this implementation returns a monotonically increasing INT64 per
 // (process, sequence-name) pair.
-var sequenceCounters = map[string]int64{}
+var (
+	sequenceCounters   = map[string]int64{}
+	sequenceCountersMu sync.Mutex
+)
 
 func BindGetNextSequenceValue(args ...value.Value) (value.Value, error) {
 	if len(args) != 1 {
@@ -279,8 +283,11 @@ func BindGetNextSequenceValue(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	sequenceCountersMu.Lock()
 	sequenceCounters[name]++
-	return value.IntValue(sequenceCounters[name]), nil
+	next := sequenceCounters[name]
+	sequenceCountersMu.Unlock()
+	return value.IntValue(next), nil
 }
 
 // BindGetInternalSequenceState returns the internal counter for a
@@ -296,5 +303,8 @@ func BindGetInternalSequenceState(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return value.IntValue(sequenceCounters[name]), nil
+	sequenceCountersMu.Lock()
+	cur := sequenceCounters[name]
+	sequenceCountersMu.Unlock()
+	return value.IntValue(cur), nil
 }

--- a/internal/functions/spanner/singletons_test.go
+++ b/internal/functions/spanner/singletons_test.go
@@ -2,6 +2,7 @@ package spanner
 
 import (
 	"math"
+	"sync"
 	"testing"
 	"time"
 
@@ -267,5 +268,59 @@ func TestBindGetNextSequenceValue(t *testing.T) {
 	}
 	if _, err := BindGetInternalSequenceState(); err == nil {
 		t.Fatal("expected arg count error")
+	}
+}
+
+// TestBindSequenceFunctionsConcurrent locks in the sequenceCounters
+// synchronisation: GET_NEXT_SEQUENCE_VALUE and
+// GET_INTERNAL_SEQUENCE_STATE are invoked as SQL function callbacks
+// from concurrently running statements (parallel spec runs hit this),
+// so the shared counter map must tolerate concurrent readers and
+// writers. Run under -race this test reproduced the original crash
+// deterministically before the mutex was added. It also checks the
+// counter never skips or repeats: N goroutines × M increments on one
+// sequence must end exactly at N*M.
+func TestBindSequenceFunctionsConcurrent(t *testing.T) {
+	t.Parallel()
+
+	const (
+		goroutines = 8
+		increments = 200
+	)
+	name := value.StringValue("test-seq-concurrent")
+
+	// The counter map is package-level and survives across -count=N
+	// reruns in one process, so assert the delta, not the absolute.
+	before, err := BindGetInternalSequenceState(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := mustInt64(t, before)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < increments; i++ {
+				if _, err := BindGetNextSequenceValue(name); err != nil {
+					t.Error(err)
+					return
+				}
+				if _, err := BindGetInternalSequenceState(name); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	state, err := BindGetInternalSequenceState(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mustInt64(t, state) - start; got != goroutines*increments {
+		t.Fatalf("counter lost updates: got %d, want %d", got, goroutines*increments)
 	}
 }


### PR DESCRIPTION
Fixes a data race in the Spanner sequence functions, found while
running the full `-race` suite on native arm64 during wasm2go PR #14
verification.

## The race

`GET_NEXT_SEQUENCE_VALUE` / `GET_INTERNAL_SEQUENCE_STATE`
(`internal/functions/spanner/singletons.go`) share a package-level
`sequenceCounters map[string]int64` with **no synchronisation**. Both
are SQL function callbacks, so parallel statements on different
connections — the spec runner's normal mode — write
(`sequenceCounters[name]++`) and read the map concurrently:

```
WARNING: DATA RACE
Write at 0x00c0000f78c0 by goroutine 2243:
  runtime.mapaccess2_faststr()
  spanner.BindGetNextSequenceValue()      singletons.go
Previous read at 0x00c0000f78c0 by goroutine 2244:
  spanner.BindGetInternalSequenceState()  singletons.go
```

Under `-race` one detection fails every test in flight (the full
suite reported ~30 unrelated spec failures from this single race);
without `-race` it is silent corruption waiting on a concurrent map
grow. Repro rate before the fix:
`GOARCH=arm64 go test -race -run 'TestSpec/spanner/functions/sequence' .`
failed 2 of 3 runs.

## Fix

A `sync.Mutex` around both accesses. NEXT_VALUE returns the value it
incremented to under the same lock, so concurrent callers can no
longer be handed another caller's increment.

## Regression test

`TestBindSequenceFunctionsConcurrent` — 8 goroutines × 200
increments on one sequence; asserts the counter advances by exactly
1600 (delta-based so `-count=N` in-process reruns stay valid).
Confirmed it fails (race + exit 1) against the unfixed code and
passes `-race -count=5` with the fix.

## Verification (all exit 0)

- `go test -race -timeout 30m ./...` (host amd64)
- `GOARCH=arm64 go test -race -timeout 30m ./...` (native arm64)
- 3× the previously-flaky targeted spec run above
- `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
