### PR TITLE
internal: keep the character after a %E combination token in FormatTime

### DIFF
--- a/internal/functions/helper/datetime_time_format_test.go
+++ b/internal/functions/helper/datetime_time_format_test.go
@@ -127,6 +127,53 @@ func TestFormatTimeCombinedSpecifiers(t *testing.T) {
 	}
 }
 
+// TestFormatTimeLiteralAfterCombination pins that literal characters
+// and further format elements following a %E-prefixed combination
+// token (%E<n>S, %E*S, %Ez, %E4Y) are emitted, not swallowed.
+//
+// Every element renders independently and literal characters in the
+// format string are copied verbatim (format-elements reference:
+// FORMAT_TIMESTAMP("%b %Y %Ez", ...) -> "Dec 2008 +00:00" keeps the
+// spaces around %Ez). The expected strings below are the documented
+// per-element renderings composed left-to-right for referenceTime
+// (2026-05-15 03:04:05.123456789 UTC).
+func TestFormatTimeLiteralAfterCombination(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		format string
+		typ    TimeFormatType
+		want   string
+	}{
+		// Trailing literal 'Z' after %E3S (the ISO "...%E3SZ" idiom).
+		{"E3S_then_Z", "%E3SZ", FormatTypeTime, "05.123Z"},
+		// Trailing literal after %E*S.
+		{"EstarS_then_Z", "%E*SZ", FormatTypeTime, "05.123456Z"},
+		// %E4Y followed by a '-' literal and another element.
+		{"E4Y_then_dash_month", "%E4Y-%m", FormatTypeDate, "2026-05"},
+		// %Ez followed by a literal character.
+		{"Ez_then_literal", "%Ez!", FormatTypeTimestamp, "+00:00!"},
+		// %Ez followed by a space and a further element.
+		{"Ez_then_space_month", "%Ez %b", FormatTypeTimestamp, "+00:00 May"},
+		// Combination token in the middle, element on both sides.
+		{"month_E3S_year", "%b %E3S %Y", FormatTypeTimestamp, "May 05.123 2026"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := FormatTime(c.format, &referenceTime, c.typ)
+			if err != nil {
+				t.Fatalf("FormatTime(%q): %v", c.format, err)
+			}
+			if got != c.want {
+				t.Fatalf("FormatTime(%q) = %q, want %q", c.format, got, c.want)
+			}
+		})
+	}
+}
+
 // TestFormatTimeErrors covers the FormatTime error paths.
 func TestFormatTimeErrors(t *testing.T) {
 	t.Parallel()

--- a/internal/functions/helper/datetime_time_parser.go
+++ b/internal/functions/helper/datetime_time_parser.go
@@ -1277,7 +1277,10 @@ func FormatTime(formatStr string, t *time.Time, typ TimeFormatType) (string, err
 					return "", err
 				}
 				ret = append(ret, formatted...)
-				i += formatProgress
+				// -1 because the loop's post-increment advances the
+				// final rune; using formatProgress would skip the
+				// character after the token (e.g. 'Z' in "%E3SZ").
+				i += formatProgress - 1
 				continue
 			}
 			info := formatPatternMap[c]

--- a/testdata/specs/googlesql/functions/timestamp/format_timestamp.yaml
+++ b/testdata/specs/googlesql/functions/timestamp/format_timestamp.yaml
@@ -7,3 +7,21 @@ cases:
     expected:
       rows:
         - ["2024-03-15T12:30:45"]
+  # A literal that follows a %E-prefixed combination token (%E*S here)
+  # must be emitted verbatim. %E*S renders seconds with full fractional
+  # precision ("45.123456"), and the trailing literal 'Z' is copied
+  # through -- it is not a format element (that would be %Z).
+  - desc: literal Z after %E*S combination token
+    sql: |
+      SELECT FORMAT_TIMESTAMP("%Y-%m-%dT%H:%M:%E*SZ", TIMESTAMP "2024-03-15 12:30:45.123456+00", "UTC")
+    expected:
+      rows:
+        - ["2024-03-15T12:30:45.123456Z"]
+  # %E4Y (four-character year) followed by a '-' literal and a further
+  # element; the '-' between the year and the month must survive.
+  - desc: literal dash after %E4Y combination token
+    sql: |
+      SELECT FORMAT_TIMESTAMP("%E4Y-%m", TIMESTAMP "2024-03-15 12:30:45+00", "UTC")
+    expected:
+      rows:
+        - ["2024-03"]


### PR DESCRIPTION
> **Note:** This PR and its linked issue were generated by AI (with human review).

## Problem

`FORMAT_TIMESTAMP`/`FORMAT_DATETIME`/`FORMAT_TIME`/`FORMAT_DATE` drop the
character immediately after any `%E`-prefixed combination element
(`%E<n>S`, `%E*S`, `%Ez`, `%E4Y`): `'%E*SZ'` loses the trailing `Z`,
`'%E4Y-%m'` loses the `-`. Only reproduces when a character *follows* the
token, so the existing tests missed it.

## Cause

`FormatTime` (`internal/functions/helper/datetime_time_parser.go`) uses a
`for i := …; i++` loop. The `%E` branch advances past the whole token
(`i += formatProgress`) before `continue`, then the loop's `i++` skips
one extra rune. The plain-specifier path relies on that `i++` for its
single advance, so only `%E` over-advances. `ParseTimeFormat` is
unaffected (no post-increment).

## Fix

`i += formatProgress - 1`, so the post-increment lands on the next token.
One line; no parsing change.

Alternative: rewrite the loop to advance `i` explicitly in every branch
(as `ParseTimeFormat` does). Rejected — larger refactor of correct code.

## Tests

`TestFormatTimeLiteralAfterCombination` plus two `FORMAT_TIMESTAMP` spec
cases (literal `Z` after `%E*S`, literal `-` after `%E4Y`). Each fails
before the fix, passes after. `go test ./...` and `specctl check --check`
pass.

Fixes #28
