### PR TITLE
string: translate REGEXP_REPLACE backreferences to RE2 correctly

### DIFF
--- a/internal/functions/string/bind_test.go
+++ b/internal/functions/string/bind_test.go
@@ -1252,20 +1252,62 @@ func TestBase32RoundTrip(t *testing.T) {
 
 // ----- REGEXP_REPLACE backreferences ---------------------------
 
+// TestRegexpReplaceBackreferences pins the BigQuery replacement grammar
+// (string_functions.md#regexp_replace): \0..\9 are single-digit group
+// references (\0 = the whole match), \\ is a literal backslash, '$' is
+// an ordinary literal, and any other escape is an error. Expected
+// values are the upstream Description/Examples plus the documented
+// single-digit and literal-backslash rules.
 func TestRegexpReplaceBackreferences(t *testing.T) {
 	t.Parallel()
-	// BQ docs Example: REGEXP_REPLACE('# Heading',
-	// '^# ([a-zA-Z0-9\\s]+$)', '<h1>\\1</h1>') -> '<h1>Heading</h1>'.
-	got, err := strfn.REGEXP_REPLACE(
-		value.StringValue("# Heading"),
-		value.StringValue(`^# ([a-zA-Z0-9\s]+$)`),
-		value.StringValue(`<h1>\1</h1>`),
-	)
-	if err != nil {
-		t.Fatalf("REGEXP_REPLACE: %v", err)
+
+	cases := []struct {
+		desc    string
+		input   string
+		expr    string
+		repl    string
+		want    string
+		wantErr bool
+	}{
+		// BQ docs Example: REGEXP_REPLACE('# Heading',
+		// '^# ([a-zA-Z0-9\s]+$)', '<h1>\1</h1>') -> '<h1>Heading</h1>'.
+		{"heading_example", "# Heading", `^# ([a-zA-Z0-9\s]+$)`, `<h1>\1</h1>`, "<h1>Heading</h1>", false},
+		// Description example: REGEXP_REPLACE('abc','b(.)','X\1') -> aXc.
+		// The backreference is the final token of the replacement.
+		{"trailing_ref", "abc", "b(.)", `X\1`, "aXc", false},
+		// \0 is the entire match.
+		{"whole_match", "abc", "b(.)", `[\0]`, "a[bc]", false},
+		// Single-digit index: \10 is group 1 then a literal '0'.
+		{"single_digit", "abcdefghijk", "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)", `\10`, "a0k", false},
+		// Consecutive references.
+		{"double_ref", "xyz", "(y)", `\1\1`, "xyyz", false},
+		// \\ -> one literal backslash.
+		{"literal_backslash", "abc", "(b)", `\\`, `a\c`, false},
+		// '$' is a literal, not the Expand sigil.
+		{"literal_dollar", "abc", "(b)", `p$q`, "ap$qc", false},
+		{"literal_dollar_brace", "abc", "(b)", `${1}`, "a${1}c", false},
+		// Invalid escapes: '\' must be followed by a digit or '\'.
+		{"backslash_nondigit", "abc", "(b)", `\q`, "", true},
+		{"trailing_backslash", "abc", "(b)", `x\`, "", true},
 	}
-	if !equalString(got, "<h1>Heading</h1>") {
-		t.Fatalf("REGEXP_REPLACE backref: got %v", got)
+	for _, c := range cases {
+		c := c
+		t.Run(c.desc, func(t *testing.T) {
+			t.Parallel()
+			got, err := strfn.REGEXP_REPLACE(value.StringValue(c.input), value.StringValue(c.expr), value.StringValue(c.repl))
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("REGEXP_REPLACE(%q,%q,%q): expected error, got %v", c.input, c.expr, c.repl, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("REGEXP_REPLACE(%q,%q,%q): %v", c.input, c.expr, c.repl, err)
+			}
+			if !equalString(got, c.want) {
+				t.Fatalf("REGEXP_REPLACE(%q,%q,%q) = %v, want %q", c.input, c.expr, c.repl, got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/functions/string/regexp_replace.go
+++ b/internal/functions/string/regexp_replace.go
@@ -26,7 +26,11 @@ func REGEXP_REPLACE(val, exprValue, replacementValue value.Value) (value.Value, 
 		if err != nil {
 			return nil, err
 		}
-		return value.StringValue(re.ReplaceAllString(v, normalizeReplacement(replacement))), nil
+		normalized, err := normalizeReplacement(replacement)
+		if err != nil {
+			return nil, err
+		}
+		return value.StringValue(re.ReplaceAllString(v, normalized)), nil
 	case value.BytesValue:
 		v, err := val.ToBytes()
 		if err != nil {
@@ -44,7 +48,11 @@ func REGEXP_REPLACE(val, exprValue, replacementValue value.Value) (value.Value, 
 		if err != nil {
 			return nil, err
 		}
-		return value.BytesValue(re.ReplaceAll(v, []byte(normalizeReplacement(string(replacement))))), nil
+		normalized, err := normalizeReplacement(string(replacement))
+		if err != nil {
+			return nil, err
+		}
+		return value.BytesValue(re.ReplaceAll(v, []byte(normalized))), nil
 	}
 	return nil, fmt.Errorf("REGEXP_REPLACE: val must be STRING or BYTES, %s", val)
 }

--- a/internal/functions/string/string_helpers.go
+++ b/internal/functions/string/string_helpers.go
@@ -9,35 +9,49 @@ func isDelim(v rune, delimiters []rune) bool {
 	return slices.Contains(delimiters, v)
 }
 
-func normalizeReplacement(repl string) string {
+// normalizeReplacement rewrites a BigQuery / GoogleSQL REGEXP_REPLACE
+// replacement string into the template syntax consumed by Go's
+// regexp.Expand (ReplaceAllString / ReplaceAll).
+//
+// The BigQuery replacement grammar (string_functions.md#regexp_replace)
+// is:
+//
+//   - \0 .. \9  insert the text captured by the corresponding group,
+//     where \0 is the entire match. The index is a SINGLE digit; a
+//     following digit is a literal (e.g. \10 is group 1 then "0").
+//   - \\        a literal backslash.
+//   - \ + other an error: "'\' must be followed by a digit or '\'".
+//   - every other byte, INCLUDING '$', is a literal.
+//
+// Go's Expand template instead spells group references "${d}" and uses
+// '$' as its sigil, so a literal '$' must be doubled to "$$".
+func normalizeReplacement(repl string) (string, error) {
 	var normalized []byte
 	for i := 0; i < len(repl); i++ {
-		switch repl[i] {
+		switch c := repl[i]; c {
 		case '\\':
-			i++
-			var tmp []byte
-			switch repl[i] {
-			case '1', '2', '3', '4', '5', '6', '7', '8', '9':
-				tmp = []byte{'$', '{', repl[i]}
-				for j := i + 1; j < len(repl); j++ {
-					switch repl[j] {
-					case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-						tmp = append(tmp, repl[j])
-						continue
-					}
-					tmp = append(tmp, '}')
-					i = j - 1
-					break
-				}
-			default:
-				tmp = []byte{'\\', repl[i]}
+			if i+1 >= len(repl) {
+				return "", fmt.Errorf("REGEXP_REPLACE: '\\' must be followed by a digit or '\\'")
 			}
-			normalized = append(normalized, tmp...)
+			next := repl[i+1]
+			switch {
+			case next >= '0' && next <= '9':
+				normalized = append(normalized, '$', '{', next, '}')
+			case next == '\\':
+				normalized = append(normalized, '\\')
+			default:
+				return "", fmt.Errorf("REGEXP_REPLACE: '\\' must be followed by a digit or '\\'")
+			}
+			i++
+		case '$':
+			// '$' is an ordinary literal in a BigQuery replacement, but
+			// the group sigil in Go's Expand template; escape it.
+			normalized = append(normalized, '$', '$')
 		default:
-			normalized = append(normalized, repl[i])
+			normalized = append(normalized, c)
 		}
 	}
-	return string(normalized)
+	return string(normalized), nil
 }
 
 var soundexMap = map[byte]byte{

--- a/testdata/specs/googlesql/functions/string/regexp_replace.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_replace.yaml
@@ -6,3 +6,65 @@ cases:
     expected:
       rows:
         - ["aXbXcX"]
+  # Upstream Example (string_functions.md#regexp_replace): a group
+  # backreference in the middle of the replacement.
+  - desc: group backreference (upstream heading example)
+    sql: |
+      SELECT REGEXP_REPLACE("# Heading", r"^# ([a-zA-Z0-9\s]+$)", r"<h1>\1</h1>")
+    expected:
+      rows:
+        - ["<h1>Heading</h1>"]
+  # Upstream Description example: "REGEXP_REPLACE('abc', 'b(.)', 'X\1')
+  # returns aXc". The backreference \1 is the final token of the
+  # replacement -- it must still resolve to group 1, not leak literally.
+  - desc: trailing group backreference
+    sql: |
+      SELECT REGEXP_REPLACE("abc", r"b(.)", r"X\1")
+    expected:
+      rows:
+        - ["aXc"]
+  # \0 refers to the entire matching text (string_functions.md: "Use \0
+  # to refer to the entire matching text.").
+  - desc: whole-match backreference with \0
+    sql: |
+      SELECT REGEXP_REPLACE("abc", r"b(.)", r"[\0]")
+    expected:
+      rows:
+        - ["a[bc]"]
+  # Backreferences are a single digit: \10 is group 1 followed by a
+  # literal '0', not group 10.
+  - desc: single-digit backreference then literal digit
+    sql: |
+      SELECT REGEXP_REPLACE("abcdefghijk", r"(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)", r"\10")
+    expected:
+      rows:
+        - ["a0k"]
+  # A literal backslash is written as \\ and produces one backslash.
+  - desc: escaped literal backslash
+    sql: |
+      SELECT REGEXP_REPLACE("abc", r"(b)", r"\\")
+    expected:
+      rows:
+        - ["a\\c"]
+  # '$' is an ordinary literal in a BigQuery replacement (unlike RE2's
+  # own Expand syntax, where '$' is the group sigil).
+  - desc: literal dollar sign in replacement
+    sql: |
+      SELECT REGEXP_REPLACE("abc", r"(b)", r"p$q")
+    expected:
+      rows:
+        - ["ap$qc"]
+  - desc: literal ${1} in replacement is not a group reference
+    sql: |
+      SELECT REGEXP_REPLACE("abc", r"(b)", r"${1}")
+    expected:
+      rows:
+        - ["a${1}c"]
+  # A backslash must be followed by a digit or another backslash;
+  # anything else is an error.
+  - desc: backslash followed by a non-digit is an error
+    sql: |
+      SELECT REGEXP_REPLACE("abc", r"(b)", r"\q")
+    expected:
+      error:
+        contains: "must be followed by a digit"


### PR DESCRIPTION
> **Note:** This PR and its accompanying issue were generated by AI (with human review).

Fixes #30

## string: translate REGEXP_REPLACE backreferences to RE2 correctly

`normalizeReplacement` rewrites a BigQuery replacement string into Go's
`regexp.Expand` template, but mistranslated the documented grammar
(`string_functions.md#regexp_replace`):

- Trailing `\N` lost its brace — `REGEXP_REPLACE('abc','b(.)','X\1')`
  returned `aX${1` instead of `aXc`.
- `\0` (whole match) leaked through literally.
- `\10` was read as group 10, not group 1 then `0` (indices are one digit).
- `\\` expanded to two backslashes instead of one.
- Literal `$` was passed straight through (it's `Expand`'s sigil), so
  `p$q` / `${1}` were misread as group refs.
- Invalid escapes were silently kept and a trailing lone `\` panicked.

Rewrite the translation: `\0`–`\9` → `${d}`, `\\` → one backslash, `$` →
`$$`, and any other escape (or a trailing `\`) → error. Deliberate
behavior change: invalid escapes now error, matching BigQuery.
`normalizeReplacement` returns an error, propagated by both the STRING
and BYTES arms.

Expand the backreference unit test into a table and add spec cases for
each rule (`want` values confirmed against real BigQuery).
`go test ./...` and `specctl check --check` pass.
