### PR TITLE
internal: fail cleanly on an unmatched format literal in ParseTimeFormat

### DIFF
--- a/internal/functions/helper/datetime_time_format_test.go
+++ b/internal/functions/helper/datetime_time_format_test.go
@@ -485,6 +485,43 @@ func TestParseTimeFormatLiteralAndWhitespace(t *testing.T) {
 	}
 }
 
+// TestParseTimeFormatLiteralMatch pins that a format literal must be
+// matched in the target: a missing or mismatched character is a clean
+// parse failure, not a panic (the ISO "%E3SZ" idiom fed a Z-less input).
+func TestParseTimeFormatLiteralMatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		format string
+		target string
+	}{
+		// Trailing literal 'Z' with the target one character short.
+		{"missing_trailing_literal", "%Y-%m-%dT%H:%M:%E3SZ", "2024-01-05T12:30:00.123"},
+		// Trailing literal present but wrong ('X' instead of 'Z').
+		{"wrong_trailing_literal", "%Y-%m-%dT%H:%M:%E3SZ", "2024-01-05T12:30:00.123X"},
+		// Literal '-' with the target exhausted just before it.
+		{"missing_mid_literal", "%Y-%m", "2024"},
+		// Literal '-' present but wrong.
+		{"wrong_mid_literal", "%Y/%m", "2024-05"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			// Must return an error and must not panic.
+			if _, err := ParseTimeFormat(c.format, c.target, FormatTypeTimestamp); err == nil {
+				t.Fatalf("ParseTimeFormat(%q, %q): expected error, got nil", c.format, c.target)
+			}
+		})
+	}
+
+	// Control: the matching literal still parses.
+	if _, err := ParseTimeFormat("%Y-%m-%dT%H:%M:%E3SZ", "2024-01-05T12:30:00.123Z", FormatTypeTimestamp); err != nil {
+		t.Fatalf("matching trailing literal must parse: %v", err)
+	}
+}
+
 // TestTimeFormatTypeString covers the TimeFormatType.String branch
 // matrix including the unknown fallback.
 func TestTimeFormatTypeString(t *testing.T) {

--- a/internal/functions/helper/datetime_time_parser.go
+++ b/internal/functions/helper/datetime_time_parser.go
@@ -1223,6 +1223,13 @@ func ParseTimeFormat(formatStr, targetStr string, typ TimeFormatType) (*time.Tim
 				targetIdx++
 			}
 		} else {
+			// A format literal must match the same character in the
+			// target; without this guard targetIdx runs past the end and
+			// panics at the target[targetIdx:] slice below. BigQuery
+			// treats a missing or mismatched literal as no match (NULL).
+			if targetIdx >= len(target) || target[targetIdx] != c {
+				return nil, fmt.Errorf("error parsing [%s] with format [%s]: expected literal %q", string(target), formatStr, string(c))
+			}
 			formatIdx++
 			targetIdx++
 		}

--- a/testdata/specs/googlesql/functions/timestamp/parse_timestamp.yaml
+++ b/testdata/specs/googlesql/functions/timestamp/parse_timestamp.yaml
@@ -7,6 +7,24 @@ cases:
     expected:
       rows:
         - [1710505845]
+  # A trailing literal in the format ('Z') with the input one character
+  # short is a clean parse failure, not a crash. BigQuery returns NULL
+  # from SAFE.PARSE_TIMESTAMP here.
+  - desc: trailing format literal missing from input fails cleanly
+    sql: |
+      SELECT PARSE_TIMESTAMP("%Y-%m-%dT%H:%M:%E3SZ", "2024-01-05T12:30:00.123")
+    expected:
+      error:
+        contains: "expected literal"
+  # A trailing literal that is present but wrong ('X' instead of 'Z') is
+  # also a parse failure, not silently accepted. BigQuery returns NULL
+  # from SAFE.PARSE_TIMESTAMP here.
+  - desc: trailing format literal mismatched in input fails cleanly
+    sql: |
+      SELECT PARSE_TIMESTAMP("%Y-%m-%dT%H:%M:%E3SZ", "2024-01-05T12:30:00.123X")
+    expected:
+      error:
+        contains: "expected literal"
   # %E3S matches up to three fractional-second digits; ".123" is within
   # precision and parses to 123000 microseconds past the second.
   - desc: fractional seconds within %E3S precision


### PR DESCRIPTION
> **Note:** This PR and its accompanying issue were generated by AI (with human review).

`PARSE_TIMESTAMP`/`PARSE_DATETIME`/`PARSE_TIME` panic when the format
holds a literal that the input is missing. The literal branch of
`ParseTimeFormat` (`internal/functions/helper/datetime_time_parser.go`)
advanced the target cursor with no bounds or match check, so it ran one
past the end of the input and the "found unparsed text" guard sliced
`target[targetIdx:]` out of range.

```sql
PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E3SZ', '2024-01-05T12:30:00.123')
--   engine: panic (slice out of range)   real BigQuery: no match (SAFE -> NULL)
```

Require the target to hold the same character as the literal, else
return a parse error — so a missing or mismatched literal is NULL under
`SAFE.PARSE_*`, matching BigQuery, instead of crashing (or, for a wrong
literal, being silently accepted). Every other branch (`%X`, `%E…`,
whitespace) already guards the cursor; only this one did not. Matching
literals still parse.

Alternative: add only the bounds check, not the match check. Rejected —
it stops the panic but still silently accepts a wrong literal.

Tests: `TestParseTimeFormatLiteralMatch` (missing / mismatched leading
and trailing literals + a matching control) and two `PARSE_TIMESTAMP`
spec cases (trailing literal missing and mismatched). Each fails before
the fix, passes after. `go test ./...` and `specctl check --check` pass.

Fixes #34
