### PR TITLE
internal: require the canonical literal for a STRING cast to a temporal type

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -458,6 +458,18 @@ func structHasMatchingNames(s *value.StructValue, fields []*googlesql.StructFiel
 	return false
 }
 
+// toTemporal converts v for a DATE / DATETIME / TIME target. A STRING
+// source must hold the canonical literal of that target -- unlike
+// Value.ToTime(), which accepts every temporal shape and would let a
+// timestamp string be truncated into a date. Other sources keep their
+// documented truncating semantics (TIMESTAMP -> DATE and friends).
+func toTemporal(v value.Value, parseLiteral func(string) (time.Time, error)) (time.Time, error) {
+	if s, ok := v.(value.StringValue); ok {
+		return parseLiteral(string(s))
+	}
+	return v.ToTime()
+}
+
 func CastValue(t googlesql.Googlesql_TypeNode, v value.Value) (value.Value, error) {
 	if v == nil {
 		return nil, nil
@@ -502,19 +514,19 @@ func CastValue(t googlesql.Googlesql_TypeNode, v value.Value) (value.Value, erro
 		}
 		return value.BytesValue(b), nil
 	case googlesql.TypeKindTypeDate:
-		t, err := v.ToTime()
+		t, err := toTemporal(v, value.ParseDateLiteral)
 		if err != nil {
 			return nil, err
 		}
 		return value.DateValue(t), nil
 	case googlesql.TypeKindTypeDatetime:
-		t, err := v.ToTime()
+		t, err := toTemporal(v, value.ParseDatetimeLiteral)
 		if err != nil {
 			return nil, err
 		}
 		return value.DatetimeValue(t), nil
 	case googlesql.TypeKindTypeTime:
-		t, err := v.ToTime()
+		t, err := toTemporal(v, value.ParseTimeLiteral)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/value/exports.go
+++ b/internal/value/exports.go
@@ -12,12 +12,15 @@ func ParseTime(s string) (time.Time, error)     { return parseTime(s) }
 func ParseTimestamp(s string, loc *time.Location) (time.Time, error) {
 	return parseTimestamp(s, loc)
 }
-func ParseInterval(s string) (*IntervalValue, error) { return parseInterval(s) }
-func IsDate(s string) bool                           { return isDate(s) }
-func IsDatetime(s string) bool                       { return isDatetime(s) }
-func IsTime(s string) bool                           { return isTime(s) }
-func IsTimestamp(s string) bool                      { return isTimestamp(s) }
-func IsNullValue(v any) bool                         { return isNullValue(v) }
+func ParseDateLiteral(s string) (time.Time, error)     { return parseDateLiteral(s) }
+func ParseDatetimeLiteral(s string) (time.Time, error) { return parseDatetimeLiteral(s) }
+func ParseTimeLiteral(s string) (time.Time, error)     { return parseTimeLiteral(s) }
+func ParseInterval(s string) (*IntervalValue, error)   { return parseInterval(s) }
+func IsDate(s string) bool                             { return isDate(s) }
+func IsDatetime(s string) bool                         { return isDatetime(s) }
+func IsTime(s string) bool                             { return isTime(s) }
+func IsTimestamp(s string) bool                        { return isTimestamp(s) }
+func IsNullValue(v any) bool                           { return isNullValue(v) }
 
 func ToLocation(timeZone string) (*time.Location, error) { return toLocation(timeZone) }
 func ModifyTimeZone(t time.Time, loc *time.Location) (time.Time, error) {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -72,6 +72,47 @@ func parseTime(t string) (time.Time, error) {
 	return time.Parse("15:04:05.999999", t)
 }
 
+// Canonical DATE / DATETIME / TIME literal layouts. Every component
+// except the year may be written with one or two digits, and a datetime
+// separates its optional time part with a space, "T" or "t"
+// (data-types.md, "Canonical format").
+const (
+	dateLiteralLayout = "2006-1-2"
+	timeLiteralLayout = "15:4:5"
+)
+
+var datetimeLiteralLayouts = []string{
+	dateLiteralLayout + " " + timeLiteralLayout,
+	dateLiteralLayout + "T" + timeLiteralLayout,
+	dateLiteralLayout + "t" + timeLiteralLayout,
+	dateLiteralLayout,
+}
+
+func parseDateLiteral(s string) (time.Time, error) {
+	t, err := time.Parse(dateLiteralLayout, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse %q as a date literal", s)
+	}
+	return t, nil
+}
+
+func parseDatetimeLiteral(s string) (time.Time, error) {
+	for _, layout := range datetimeLiteralLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("failed to parse %q as a datetime literal", s)
+}
+
+func parseTimeLiteral(s string) (time.Time, error) {
+	t, err := time.Parse(timeLiteralLayout, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse %q as a time literal", s)
+	}
+	return t, nil
+}
+
 func parseTimestamp(timestamp string, loc *time.Location) (time.Time, error) {
 	if t, err := time.ParseInLocation("2006-01-02T15:04:05.999999999Z07:00", timestamp, loc); err == nil {
 		return t, nil

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -29,3 +29,48 @@ func TestTimestampValue(t *testing.T) {
 		t.Fatalf("failed to format timestamp")
 	}
 }
+
+// The canonical literal parsers back the STRING -> DATE / DATETIME / TIME
+// cast, so each one must accept its own literal -- including the
+// one-digit component forms -- and reject every other temporal shape.
+func TestParseLiterals(t *testing.T) {
+	tests := []struct {
+		name  string
+		parse func(string) (time.Time, error)
+		in    string
+		want  string // RFC3339Nano, or "" when the parse must fail
+	}{
+		{"date", parseDateLiteral, "2024-01-15", "2024-01-15T00:00:00Z"},
+		{"date one-digit month and day", parseDateLiteral, "2024-1-5", "2024-01-05T00:00:00Z"},
+		{"date with time", parseDateLiteral, "2024-01-15 00:00:00", ""},
+		{"date with zone", parseDateLiteral, "2024-01-15T00:00:00Z", ""},
+		{"datetime space separator", parseDatetimeLiteral, "2024-01-15 10:30:00", "2024-01-15T10:30:00Z"},
+		{"datetime T separator", parseDatetimeLiteral, "2024-01-15T10:30:00", "2024-01-15T10:30:00Z"},
+		{"datetime t separator", parseDatetimeLiteral, "2024-01-15t10:30:00", "2024-01-15T10:30:00Z"},
+		{"datetime fractional seconds", parseDatetimeLiteral, "2024-01-15 10:30:00.123", "2024-01-15T10:30:00.123Z"},
+		{"datetime without time part", parseDatetimeLiteral, "2024-01-15", "2024-01-15T00:00:00Z"},
+		{"datetime with zone", parseDatetimeLiteral, "2024-01-15 10:30:00+00", ""},
+		{"time", parseTimeLiteral, "10:30:00", "0000-01-01T10:30:00Z"},
+		{"time one-digit components", parseTimeLiteral, "1:2:3", "0000-01-01T01:02:03Z"},
+		{"time fractional seconds", parseTimeLiteral, "10:30:00.123456", "0000-01-01T10:30:00.123456Z"},
+		{"time with date", parseTimeLiteral, "2024-01-15 10:30:00", ""},
+		{"time with zone", parseTimeLiteral, "10:30:00Z", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.parse(tt.in)
+			if tt.want == "" {
+				if err == nil {
+					t.Fatalf("parsed %q as %s, want a parse error", tt.in, got.Format(time.RFC3339Nano))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if formatted := got.Format(time.RFC3339Nano); formatted != tt.want {
+				t.Fatalf("parsed %q as %s, want %s", tt.in, formatted, tt.want)
+			}
+		})
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -5444,7 +5444,7 @@ SELECT item FROM Produce WHERE Produce.category = 'vegetable' QUALIFY RANK() OVE
 		{
 			name:        "cast integer to datetime",
 			query:       `WITH toks AS (SELECT "20100317" AS dt) SELECT CAST(dt AS DATETIME) FROM toks;`,
-			expectedErr: "failed to convert 20100317 to time.Time type",
+			expectedErr: `failed to parse "20100317" as a datetime literal`,
 		},
 		{
 			name:         "safe cast",

--- a/regression_test.go
+++ b/regression_test.go
@@ -2277,3 +2277,98 @@ func TestRegression_InUnnestArrayParam(t *testing.T) {
 		}
 	}
 }
+
+// TestRegression_StringToTemporalCastRequiresCanonicalLiteral asserts that a
+// STRING cast to DATE, DATETIME or TIME accepts exactly the canonical literal
+// of the target type.
+//
+// Regression: the runtime cast (a column value, i.e. everything the analyzer
+// does not constant-fold) routed every temporal target through one
+// shape-agnostic string parser. A timestamp-shaped string was therefore
+// truncated into a DATE instead of being rejected, while the canonical
+// one-digit forms the parser did not recognize were rejected instead of
+// accepted -- both directions disagreeing with the constant-folded path.
+func TestRegression_StringToTemporalCastRequiresCanonicalLiteral(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("googlesqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	null := sql.NullString{}
+	str := func(s string) sql.NullString { return sql.NullString{String: s, Valid: true} }
+
+	cases := []struct {
+		target string
+		input  string
+		want   sql.NullString
+	}{
+		// YYYY-[M]M-[D]D, and nothing else.
+		{"DATE", "2024-01-15", str("2024-01-15")},
+		{"DATE", "2024-1-5", str("2024-01-05")},
+		{"DATE", "2024-01-15T10:30:00.000Z", null},
+		{"DATE", "2024-01-15T00:00:00", null},
+		{"DATE", "2024-01-15 00:00:00", null},
+		{"DATE", "10:30:00", null},
+		{"DATE", "not-a-date", null},
+		// civil_date_part[{ |T|t}[H]H:[M]M:[S]S[.F]], no time zone.
+		{"DATETIME", "2024-01-15", str("2024-01-15T00:00:00")},
+		{"DATETIME", "2024-01-15 10:30:00", str("2024-01-15T10:30:00")},
+		{"DATETIME", "2024-01-15T10:30:00", str("2024-01-15T10:30:00")},
+		{"DATETIME", "2024-01-15t10:30:00", str("2024-01-15T10:30:00")},
+		{"DATETIME", "2024-01-15 10:30:00.123", str("2024-01-15T10:30:00.123")},
+		{"DATETIME", "2024-1-5 1:2:3", str("2024-01-05T01:02:03")},
+		{"DATETIME", "2024-01-15 10:30:00+00", null},
+		{"DATETIME", "2024-01-15T10:30:00.000Z", null},
+		// [H]H:[M]M:[S]S[.F], no date and no time zone.
+		{"TIME", "10:30:00", str("10:30:00")},
+		{"TIME", "1:2:3", str("01:02:03")},
+		{"TIME", "10:30:00.123456", str("10:30:00.123456")},
+		{"TIME", "10:30:00Z", null},
+		{"TIME", "2024-01-15", null},
+		{"TIME", "2024-01-15T10:30:00.000Z", null},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.target+"/"+tc.input, func(t *testing.T) {
+			// The column reference keeps the cast away from the analyzer's
+			// constant folder, so it runs through the driver's cast path.
+			q := fmt.Sprintf(
+				"SELECT CAST(SAFE_CAST(v AS %s) AS STRING) FROM (SELECT %q AS v)",
+				tc.target, tc.input)
+			var got sql.NullString
+			if err := db.QueryRowContext(ctx, q).Scan(&got); err != nil {
+				t.Fatalf("%s: %v", q, err)
+			}
+			if got != tc.want {
+				t.Errorf("%s\n got  %#v\n want %#v", q, got, tc.want)
+			}
+		})
+	}
+
+	// A string that does carry a time zone stays a valid TIMESTAMP.
+	t.Run("TIMESTAMP/zoned string still parses", func(t *testing.T) {
+		var got int64
+		q := `SELECT UNIX_SECONDS(SAFE_CAST(v AS TIMESTAMP)) FROM (SELECT '2024-01-15T10:30:00.000Z' AS v)`
+		if err := db.QueryRowContext(ctx, q).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", q, err)
+		}
+		if want := int64(1705314600); got != want {
+			t.Errorf("got %d want %d", got, want)
+		}
+	})
+
+	// Non-string sources keep their documented truncating semantics.
+	t.Run("TIMESTAMP source still truncates to DATE", func(t *testing.T) {
+		var got string
+		q := `SELECT CAST(SAFE_CAST(v AS DATE) AS STRING) FROM (SELECT TIMESTAMP '2024-01-15 10:30:00' AS v)`
+		if err := db.QueryRowContext(ctx, q).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", q, err)
+		}
+		if want := "2024-01-15"; got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+}

--- a/testdata/specs/googlesql/functions/conversion/safe_cast.yaml
+++ b/testdata/specs/googlesql/functions/conversion/safe_cast.yaml
@@ -11,3 +11,57 @@ cases:
     expected:
       rows:
         - [null]
+  # Casting a STRING to a temporal type requires the canonical literal of
+  # the target type (conversion_functions.md: "the string must conform to
+  # the supported date literal format"), so a timestamp-shaped string is
+  # not a DATE and SAFE_CAST returns NULL instead of truncating it. The
+  # subquery keeps the cast out of the analyzer's constant folder.
+  - desc: string to date rejects a timestamp-shaped string
+    sql: SELECT SAFE_CAST(v AS DATE) FROM (SELECT "2024-01-15T10:30:00.000Z" AS v)
+    expected:
+      rows:
+        - [null]
+  - desc: string to date rejects a datetime-shaped string
+    sql: SELECT SAFE_CAST(v AS DATE) FROM (SELECT "2024-01-15 00:00:00" AS v)
+    expected:
+      rows:
+        - [null]
+  - desc: string to date rejects a time-shaped string
+    sql: SELECT SAFE_CAST(v AS DATE) FROM (SELECT "10:30:00" AS v)
+    expected:
+      rows:
+        - [null]
+  # YYYY-[M]M-[D]D: the month and day may be one or two digits.
+  - desc: string to date accepts the canonical date literal
+    sql: SELECT SAFE_CAST(v AS DATE) FROM (SELECT "2024-1-5" AS v)
+    expected:
+      rows:
+        - ["2024-01-05"]
+  # A datetime literal has no time zone, and its time part may be
+  # introduced by a space, "T" or "t".
+  - desc: string to datetime rejects a zoned string
+    sql: SELECT SAFE_CAST(v AS DATETIME) FROM (SELECT "2024-01-15T10:30:00.000Z" AS v)
+    expected:
+      rows:
+        - [null]
+  - desc: string to datetime accepts the lowercase t separator
+    sql: SELECT CAST(SAFE_CAST(v AS DATETIME) AS STRING) FROM (SELECT "2024-01-15t10:30:00" AS v)
+    expected:
+      rows:
+        - ["2024-01-15T10:30:00"]
+  - desc: string to time rejects a date-shaped string
+    sql: SELECT SAFE_CAST(v AS TIME) FROM (SELECT "2024-01-15" AS v)
+    expected:
+      rows:
+        - [null]
+  - desc: string to time accepts one-digit hour, minute and second
+    sql: SELECT CAST(SAFE_CAST(v AS TIME) AS STRING) FROM (SELECT "1:2:3" AS v)
+    expected:
+      rows:
+        - ["01:02:03"]
+  # A timestamp literal may carry a time zone, so this one still parses.
+  - desc: string to timestamp accepts a zoned string
+    sql: SELECT UNIX_SECONDS(SAFE_CAST(v AS TIMESTAMP)) FROM (SELECT "2024-01-15T10:30:00.000Z" AS v)
+    expected:
+      rows:
+        - [1705314600]

--- a/testdata/specs/googlesql/syntax/query/cast.yaml
+++ b/testdata/specs/googlesql/syntax/query/cast.yaml
@@ -21,3 +21,17 @@ cases:
     expected:
       rows:
         - ['true']
+  # A string that is not a date literal is an error under CAST (the
+  # SAFE_CAST spec covers the NULL form). The subquery keeps the cast out
+  # of the analyzer's constant folder.
+  - desc: cast string to date rejects a timestamp-shaped string
+    sql: SELECT CAST(v AS DATE) AS r FROM (SELECT '2024-01-15T10:30:00.000Z' AS v)
+    expected:
+      error:
+        contains: "as a date literal"
+  # A timestamp source is truncated as documented, not rejected.
+  - desc: cast timestamp to date truncates
+    sql: SELECT CAST(v AS DATE) AS r FROM (SELECT TIMESTAMP '2024-01-15 10:30:00' AS v)
+    expected:
+      rows:
+        - ["2024-01-15"]


### PR DESCRIPTION
> **Note:** This PR and its linked issue were generated by AI (with human review).

## Problem

A runtime `CAST(STRING AS DATE)` (also `DATETIME`, `TIME`) ignores the
target type and parses the string as whatever temporal shape it matches,
which is wrong in both directions:

- too lenient — an ISO-8601 timestamp is truncated into a `DATE`
  (`SAFE_CAST(v AS DATE)` on `'2024-01-15T10:30:00.000Z'` → `2024-01-15`,
  want NULL), a zoned string casts to `DATETIME`, a date casts to `TIME`;
- too strict — the canonical one-digit forms and the lowercase `t`
  datetime separator are rejected (`'2024-1-5'` as DATE, `'1:2:3'` as
  TIME → NULL, want `2024-01-05` / `01:02:03`).

GoogleSQL requires the string to conform to the target's literal format.
A literal argument is folded by the analyzer and is already correct, so
the two paths disagree.

## Cause

`CastValue` (`internal/encoder.go`) sends DATE/DATETIME/TIME targets
through `Value.ToTime()`, which tries date → datetime → time → timestamp
in turn regardless of the target.

## Fix

Parse a `STRING` source with the canonical literal layout of the target
type (one or two digits per component; space/`T`/`t` before a datetime's
optional time part). Non-string sources keep `ToTime()`, so
`TIMESTAMP -> DATE` still truncates as documented; `TIMESTAMP` targets
are unchanged.

Alternatives: splitting `ToTime()` across the `Value` interface (three
new methods on 20 implementations for one call site), or tightening the
`isDate`/`isDatetime`/`isTime` predicates (they are the dispatch table of
`ToTime()` itself, shared with `BytesValue`). Both rejected.

## Tests

`TestRegression_StringToTemporalCastRequiresCanonicalLiteral` (the full
accept/reject matrix over the runtime path — both the wrongly-accepted
and the wrongly-rejected rows — plus TIMESTAMP-target and
TIMESTAMP-source controls), `TestParseLiterals` for the new parsers, and
`SAFE_CAST` / `CAST` spec cases. Each fails before the fix, passes after.
Expectations are the analyzer's folded results, verified against
BigQuery. One existing case pins the error *message* of an
already-rejected cast; only that string changes.

`go test ./...` and `make validate` (707 specs) pass. `make lint` reports
two pre-existing `SA5011` findings in `driver_test.go`, unrelated.

Closes #40
