### PR TITLE
string: honor INSTR position semantics (past-the-end, negative, characters)

### DIFF
--- a/internal/functions/string/bind_test.go
+++ b/internal/functions/string/bind_test.go
@@ -440,6 +440,63 @@ func TestInstr(t *testing.T) {
 	}
 }
 
+func TestInstrPositionSemantics(t *testing.T) {
+	t.Parallel()
+
+	s := func(v string) value.Value { return value.StringValue(v) }
+	b := func(v string) value.Value { return value.BytesValue(v) }
+	n := func(v int64) value.Value { return value.IntValue(v) }
+	for _, tc := range []struct {
+		args []value.Value
+		want int64
+	}{
+		{[]value.Value{s("banana"), s("an"), n(1), n(1)}, 2},
+		{[]value.Value{s("banana"), s("an"), n(1), n(2)}, 4},
+		{[]value.Value{s("banana"), s("an"), n(1), n(3)}, 0},
+		{[]value.Value{s("banana"), s("an"), n(3), n(1)}, 4},
+		{[]value.Value{s("banana"), s("an"), n(-1), n(1)}, 4},
+		{[]value.Value{s("banana"), s("an"), n(-3), n(1)}, 4},
+		{[]value.Value{s("banana"), s("ann"), n(1), n(1)}, 0},
+		{[]value.Value{s("a"), s("a"), n(1)}, 1},
+		{[]value.Value{s("banana"), s("a"), n(6)}, 6},
+		{[]value.Value{s("banana"), s("a"), n(7)}, 0},
+		{[]value.Value{s("banana"), s("a"), n(-7)}, 0},
+		{[]value.Value{s("banana"), s("an"), n(-4), n(1)}, 2},
+		{[]value.Value{s("banana"), s("an"), n(-6), n(1)}, 0},
+		{[]value.Value{s("banana"), s("na"), n(-1), n(1)}, 5},
+		{[]value.Value{s("banana"), s("an"), n(-1), n(2)}, 2},
+		{[]value.Value{s("banana"), s("b"), n(-6)}, 1},
+		{[]value.Value{s("banana"), s("ana"), n(1), n(2)}, 4},
+		{[]value.Value{s("aaaa"), s("aa"), n(1), n(2)}, 2},
+		{[]value.Value{s("aaaa"), s("aa"), n(-1), n(2)}, 2},
+		{[]value.Value{s("aaaa"), s("aa"), n(-2), n(1)}, 3},
+		{[]value.Value{s("щцф"), s("ц")}, 2},
+		{[]value.Value{s("щцфц"), s("ц"), n(3)}, 4},
+		{[]value.Value{s("щцф"), s("ф"), n(-1)}, 3},
+		{[]value.Value{s("banana"), s(""), n(3)}, 3},
+		{[]value.Value{s("banana"), s(""), n(7)}, 7},
+		{[]value.Value{s("banana"), s(""), n(8)}, 0},
+		{[]value.Value{s("banana"), s(""), n(-1)}, 7},
+		{[]value.Value{s("banana"), s(""), n(-2), n(2)}, 5},
+		{[]value.Value{s("banana"), s(""), n(-7)}, 1},
+		{[]value.Value{s("banana"), s(""), n(-8)}, 0},
+		{[]value.Value{s(""), s(""), n(1)}, 1},
+		{[]value.Value{s(""), s("a")}, 0},
+		{[]value.Value{b("щцф"), b("ф")}, 5},
+		{[]value.Value{b("\xff\x00\xff"), b("\xff"), n(2)}, 3},
+		{[]value.Value{b("\xff\x00\xff"), b("\xff"), n(-1), n(2)}, 1},
+	} {
+		got, err := strfn.BindInstr(tc.args...)
+		if err != nil {
+			t.Errorf("INSTR%v: %v", tc.args, err)
+			continue
+		}
+		if i, _ := got.ToInt64(); i != tc.want {
+			t.Errorf("INSTR%v: got %d, want %d", tc.args, i, tc.want)
+		}
+	}
+}
+
 // ----- CONCAT ------------------------------------------------------
 
 func TestConcat(t *testing.T) {
@@ -1063,12 +1120,15 @@ func TestInstrBytesAndNegativePos(t *testing.T) {
 	}
 	// INSTR with negative position (search from the right).
 	got, _ = strfn.BindInstr(value.StringValue("banana"), value.StringValue("an"), value.IntValue(-1))
-	if got == nil {
-		t.Errorf("INSTR neg pos returned nil")
+	if i, _ := got.ToInt64(); i != 4 {
+		t.Errorf("INSTR neg pos: got %d, want 4", i)
 	}
-	// position past length -> error.
-	if _, err := strfn.BindInstr(value.StringValue("ab"), value.StringValue("a"), value.IntValue(100)); err == nil {
-		t.Errorf("INSTR pos too large should fail")
+	// position past length -> 0.
+	got, err := strfn.BindInstr(value.StringValue("ab"), value.StringValue("a"), value.IntValue(100))
+	if err != nil {
+		t.Errorf("INSTR pos too large: %v", err)
+	} else if i, _ := got.ToInt64(); i != 0 {
+		t.Errorf("INSTR pos too large: got %d, want 0", i)
 	}
 	// Different source / search types -> error.
 	if _, err := strfn.BindInstr(value.StringValue("ab"), value.BytesValue("a")); err == nil {

--- a/internal/functions/string/instr.go
+++ b/internal/functions/string/instr.go
@@ -1,10 +1,7 @@
 package string
 
 import (
-	"bytes"
 	"fmt"
-	"math"
-	"strings"
 
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
@@ -12,87 +9,86 @@ import (
 
 func INSTR(source, search value.Value, position, occurrence int64) (value.Value, error) {
 	if position == 0 {
-		return nil, fmt.Errorf("INSTR: invalid position number. position is must be large than zero value")
+		return nil, fmt.Errorf("INSTR: position must be non-zero")
 	}
 	if occurrence <= 0 {
-		return nil, fmt.Errorf("INSTR: invalid occurrence number. occurrence is must be large than zero value. but specified %d", occurrence)
+		return nil, fmt.Errorf("INSTR: occurrence must be positive, but got %d", occurrence)
 	}
-	pos := int(math.Abs(float64(position)))
 	if _, ok := source.(value.StringValue); ok {
 		if _, ok := search.(value.StringValue); !ok {
-			return nil, fmt.Errorf("INSTR: source and search are must be same type")
+			return nil, fmt.Errorf("INSTR: value and subvalue must be the same type")
 		}
 		src, err := source.ToString()
 		if err != nil {
 			return nil, err
 		}
-		search, err := search.ToString()
+		sub, err := search.ToString()
 		if err != nil {
 			return nil, err
 		}
-		if pos >= len(src) {
-			return nil, fmt.Errorf("INSTR: invalid position number. position %d is larger than source value length %d", pos, len(src))
-		}
-		length := len(src)
-		if position < 0 {
-			src = src[:len(src)-pos+1]
-		} else {
-			src = src[pos-1:]
-		}
-		var found int64
-		for i := 0; i < len(src); i++ {
-			idx := strings.Index(src[i:], search)
-			if idx >= 0 {
-				found++
-				i += idx
-			}
-			if found == occurrence {
-				if position < 0 {
-					return value.IntValue(length - i - 1), nil
-				}
-				return value.IntValue(pos + i), nil
-			}
-		}
-		return value.IntValue(0), nil
+		return value.IntValue(instr([]rune(src), []rune(sub), position, occurrence)), nil
 	}
 	if _, ok := source.(value.BytesValue); ok {
 		if _, ok := search.(value.BytesValue); !ok {
-			return nil, fmt.Errorf("INSTR: source and search are must be same type")
+			return nil, fmt.Errorf("INSTR: value and subvalue must be the same type")
 		}
 		src, err := source.ToBytes()
 		if err != nil {
 			return nil, err
 		}
-		search, err := search.ToBytes()
+		sub, err := search.ToBytes()
 		if err != nil {
 			return nil, err
 		}
-		if pos >= len(src) {
-			return nil, fmt.Errorf("INSTR: invalid position number. position %d is larger than source value length %d", pos, len(src))
-		}
-		length := len(src)
-		if position < 0 {
-			src = src[:len(src)-pos+1]
-		} else {
-			src = src[pos-1:]
-		}
-		var found int64
-		for i := 0; i < len(src); i++ {
-			idx := bytes.Index(src[i:], search)
-			if idx >= 0 {
-				found++
-				i += idx
-			}
-			if found == occurrence {
-				if position < 0 {
-					return value.IntValue(length - i - 1), nil
-				}
-				return value.IntValue(pos + i), nil
-			}
-		}
-		return value.IntValue(0), nil
+		return value.IntValue(instr(src, sub, position, occurrence)), nil
 	}
-	return nil, fmt.Errorf("INSTR: source and search type are must be STRING or BYTES type")
+	return nil, fmt.Errorf("INSTR: value and subvalue must be STRING or BYTES")
+}
+
+// An empty sub also matches just past the last element, hence len(src)+1
+// addressable positions.
+func instr[T comparable](src, sub []T, position, occurrence int64) int64 {
+	n := int64(len(src))
+	if len(sub) == 0 {
+		n++
+	}
+	matchesAt := func(s int64) bool {
+		if s+int64(len(sub)) > int64(len(src)) {
+			return false
+		}
+		for i, c := range sub {
+			if src[s+int64(i)] != c {
+				return false
+			}
+		}
+		return true
+	}
+	if position > 0 {
+		if position > n {
+			return 0
+		}
+		for s := position - 1; s < n; s++ {
+			if matchesAt(s) {
+				occurrence--
+				if occurrence == 0 {
+					return s + 1
+				}
+			}
+		}
+		return 0
+	}
+	if -position > n {
+		return 0
+	}
+	for s := n + position; s >= 0; s-- {
+		if matchesAt(s) {
+			occurrence--
+			if occurrence == 0 {
+				return s + 1
+			}
+		}
+	}
+	return 0
 }
 
 var BindInstr = helper.ScalarN(func(args ...value.Value) (value.Value, error) {
@@ -100,9 +96,6 @@ var BindInstr = helper.ScalarN(func(args ...value.Value) (value.Value, error) {
 		return nil, fmt.Errorf("INSTR: invalid number of arguments: got %d, want one of 2, 3, 4", len(args))
 	}
 	var (
-		// Per BigQuery docs, position defaults to 1 (start from the
-		// first character). The previous default of 0 tripped the
-		// `position > 0` guard in INSTR for 2-arg calls.
 		position   int64 = 1
 		occurrence int64 = 1
 	)

--- a/testdata/specs/googlesql/functions/string/instr.yaml
+++ b/testdata/specs/googlesql/functions/string/instr.yaml
@@ -6,3 +6,84 @@ cases:
     expected:
       rows:
         - [2]
+  # Upstream Examples (string_functions.md#instr), in order.
+  - desc: first occurrence from position 1
+    sql: SELECT INSTR('banana', 'an', 1, 1)
+    expected:
+      rows:
+        - [2]
+  - desc: second occurrence from position 1
+    sql: SELECT INSTR('banana', 'an', 1, 2)
+    expected:
+      rows:
+        - [4]
+  - desc: occurrence beyond the number of matches returns 0
+    sql: SELECT INSTR('banana', 'an', 1, 3)
+    expected:
+      rows:
+        - [0]
+  - desc: search starts at position 3
+    sql: SELECT INSTR('banana', 'an', 3, 1)
+    expected:
+      rows:
+        - [4]
+  - desc: negative position -1 searches backwards from the last character
+    sql: SELECT INSTR('banana', 'an', -1, 1)
+    expected:
+      rows:
+        - [4]
+  - desc: negative position -3 still finds the match starting at that character
+    sql: SELECT INSTR('banana', 'an', -3, 1)
+    expected:
+      rows:
+        - [4]
+  - desc: no match returns 0
+    sql: SELECT INSTR('banana', 'ann', 1, 1)
+    expected:
+      rows:
+        - [0]
+  - desc: position equal to the value length is valid
+    sql: SELECT INSTR('a', 'a', 1), INSTR('banana', 'a', 6)
+    expected:
+      rows:
+        - [1, 6]
+  - desc: position past the value length returns 0 in both directions
+    sql: SELECT INSTR('banana', 'a', 7), INSTR('banana', 'a', -7)
+    expected:
+      rows:
+        - [0, 0]
+  - desc: negative position anchors the latest allowed match start
+    sql: SELECT INSTR('banana', 'an', -4, 1), INSTR('banana', 'na', -1, 1), INSTR('banana', 'an', -1, 2)
+    expected:
+      rows:
+        - [2, 5, 2]
+  - desc: overlapping occurrences are counted in both directions
+    sql: SELECT INSTR('banana', 'ana', 1, 2), INSTR('aaaa', 'aa', 1, 2), INSTR('aaaa', 'aa', -1, 2)
+    expected:
+      rows:
+        - [4, 2, 2]
+  - desc: STRING positions count characters and BYTES positions count bytes
+    sql: SELECT INSTR('щцф', 'ф'), INSTR('щцфц', 'ц', 3), INSTR('щцф', 'ф', -1), INSTR(b'щцф', b'ф')
+    expected:
+      rows:
+        - [3, 4, 3, 5]
+  - desc: empty subvalue matches at every position including one past the end
+    sql: SELECT INSTR('banana', '', 3), INSTR('banana', '', 7), INSTR('banana', '', 8), INSTR('banana', '', -1), INSTR('', '', 1)
+    expected:
+      rows:
+        - [3, 7, 0, 7, 1]
+  - desc: NULL argument returns NULL
+    sql: SELECT INSTR(CAST(NULL AS STRING), 'a'), INSTR('banana', 'a', NULL)
+    expected:
+      rows:
+        - [null, null]
+  - desc: position 0 is an error
+    sql: SELECT INSTR('banana', 'a', 0)
+    expected:
+      error:
+        contains: "position must be non-zero"
+  - desc: non-positive occurrence is an error
+    sql: SELECT INSTR('banana', 'a', 1, 0)
+    expected:
+      error:
+        contains: "occurrence must be positive"


### PR DESCRIPTION
> **Note:** This PR and its accompanying issue were generated by AI (with human review).

Fixes #45

## string: honor INSTR position semantics (past-the-end, negative, characters)

`INSTR` rejected any position at or beyond the value length with
"invalid position number", so `INSTR('a', 'a', 1)` errored instead of
returning `1`, and a position past the end errored instead of returning
`0` as documented (`string_functions.md#instr`, "Returns 0 if"). Negative
positions searched a truncated prefix forwards rather than backwards from
the anchor, STRING positions were counted in bytes rather than characters,
and an empty subvalue errored.

| SQL | before | after (docs / BigQuery) |
| -- | -- | -- |
| `INSTR('a', 'a', 1)` | error | `1` |
| `INSTR('banana', 'a', 7)` | error | `0` |
| `INSTR('banana', 'an', -4, 1)` | `4` | `2` |
| `INSTR('banana', 'na', -1, 1)` | `3` | `5` |
| `INSTR('щцф', 'ц')` | `3` | `2` |
| `INSTR('banana', '', 3)` | error | `3` |

Rewrite the search over a generic slice (`[]rune` for STRING, `[]byte`
for BYTES): forward scans start at `position`, backward scans accept
matches starting at or before the anchor and count occurrences right to
left, overlapping matches count, `|position|` beyond the addressable
range returns `0`. `position = 0` and `occurrence <= 0` remain errors.

Adds the seven upstream Examples plus edge cases to
`testdata/specs/googlesql/functions/string/instr.yaml` and a table-driven
unit test; the existing "position past length -> error" assertion is
corrected to the documented `0`. `want` values for the non-Example cases
were confirmed against BigQuery. `go test ./...`,
`go run ./cmd/specctl check --check` and `make lint` pass.
