### PR TITLE
string: validate arguments instead of panicking

### DIFF
--- a/internal/functions/string/ascii.go
+++ b/internal/functions/string/ascii.go
@@ -1,21 +1,34 @@
 package string
 
 import (
+	"fmt"
+	"unicode/utf8"
+
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
-func ASCII(v string) (value.Value, error) {
-	return value.IntValue(v[0]), nil
-}
-
-var BindAscii = helper.Scalar1(func(a value.Value) (value.Value, error) {
-	ascii, err := a.ToString()
+func ASCII(v value.Value) (value.Value, error) {
+	if b, ok := v.(value.BytesValue); ok {
+		if len(b) == 0 {
+			return value.IntValue(0), nil
+		}
+		return value.IntValue(int64(b[0])), nil
+	}
+	s, err := v.ToString()
 	if err != nil {
 		return nil, err
 	}
-	if ascii == "" {
+	if s == "" {
 		return value.IntValue(0), nil
 	}
-	return ASCII(ascii)
+	r, _ := utf8.DecodeRuneInString(s)
+	if r >= utf8.RuneSelf {
+		return nil, fmt.Errorf("ASCII: argument is not a structurally valid ASCII string: '%s'", s)
+	}
+	return value.IntValue(int64(r)), nil
+}
+
+var BindAscii = helper.Scalar1(func(a value.Value) (value.Value, error) {
+	return ASCII(a)
 })

--- a/internal/functions/string/bind_test.go
+++ b/internal/functions/string/bind_test.go
@@ -1290,6 +1290,10 @@ func TestRegexpReplaceBackreferences(t *testing.T) {
 		// Invalid escapes: '\' must be followed by a digit or '\'.
 		{"backslash_nondigit", "abc", "(b)", `\q`, "", true},
 		{"trailing_backslash", "abc", "(b)", `x\`, "", true},
+		// A backreference the pattern cannot satisfy is an error, not
+		// an empty substitution.
+		{"group_out_of_range", "abc", "b(.)", `X\2`, "", true},
+		{"group_without_any", "abc", "b", `X\1`, "", true},
 	}
 	for _, c := range cases {
 		c := c

--- a/internal/functions/string/bind_test.go
+++ b/internal/functions/string/bind_test.go
@@ -1252,12 +1252,12 @@ func TestBase32RoundTrip(t *testing.T) {
 
 // ----- REGEXP_REPLACE backreferences ---------------------------
 
-// TestRegexpReplaceBackreferences pins the BigQuery replacement grammar
-// (string_functions.md#regexp_replace): \0..\9 are single-digit group
-// references (\0 = the whole match), \\ is a literal backslash, '$' is
-// an ordinary literal, and any other escape is an error. Expected
-// values are the upstream Description/Examples plus the documented
-// single-digit and literal-backslash rules.
+// TestRegexpReplaceBackreferences pins the replacement grammar: \0..\9
+// are group references (\0 = the whole match) and \\ is a literal
+// backslash, per string_functions.md#regexp_replace; the index being a
+// single digit, '$' being an ordinary literal and any other escape
+// being an error come from the reference implementation
+// (`regexp.cc:536`, `1f8aa33`).
 func TestRegexpReplaceBackreferences(t *testing.T) {
 	t.Parallel()
 
@@ -1277,7 +1277,8 @@ func TestRegexpReplaceBackreferences(t *testing.T) {
 		{"trailing_ref", "abc", "b(.)", `X\1`, "aXc", false},
 		// \0 is the entire match.
 		{"whole_match", "abc", "b(.)", `[\0]`, "a[bc]", false},
-		// Single-digit index: \10 is group 1 then a literal '0'.
+		// Single-digit index (reference implementation): \10 is group 1
+		// then a literal '0'.
 		{"single_digit", "abcdefghijk", "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)", `\10`, "a0k", false},
 		// Consecutive references.
 		{"double_ref", "xyz", "(y)", `\1\1`, "xyyz", false},

--- a/internal/functions/string/chr.go
+++ b/internal/functions/string/chr.go
@@ -1,6 +1,8 @@
 package string
 
 import (
+	"fmt"
+
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
@@ -9,11 +11,10 @@ func CHR(v int64) (value.Value, error) {
 	if v == 0 {
 		return value.StringValue(""), nil
 	}
-	r, err := helper.SafeInt32(v)
-	if err != nil {
-		return nil, err
+	if !validCodePoint(v) {
+		return nil, fmt.Errorf("CHR: Invalid codepoint %d", v)
 	}
-	return value.StringValue(string(rune(r))), nil
+	return value.StringValue(string(rune(v))), nil
 }
 
 var BindChr = helper.Scalar1(func(a value.Value) (value.Value, error) {

--- a/internal/functions/string/code_points_to_string.go
+++ b/internal/functions/string/code_points_to_string.go
@@ -1,6 +1,8 @@
 package string
 
 import (
+	"fmt"
+
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
@@ -18,11 +20,10 @@ func CODE_POINTS_TO_STRING(v *value.ArrayValue) (value.Value, error) {
 		if i64 == 0 {
 			continue
 		}
-		r, err := helper.SafeInt32(i64)
-		if err != nil {
-			return nil, err
+		if !validCodePoint(i64) {
+			return nil, fmt.Errorf("CODE_POINTS_TO_STRING: Invalid codepoint %d", i64)
 		}
-		runes = append(runes, rune(r))
+		runes = append(runes, rune(i64))
 	}
 	return value.StringValue(string(runes)), nil
 }

--- a/internal/functions/string/collate.go
+++ b/internal/functions/string/collate.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/goccy/googlesqlite/internal/value"
-	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 )
 
@@ -14,10 +13,20 @@ func COLLATE(v, spec string) (value.Value, error) {
 		return value.StringValue(v), nil
 	}
 	splitted := strings.SplitN(spec, ":", 2)
-	if len(splitted) == 0 {
-		return nil, fmt.Errorf("COLLATE: unexpected spec literal %s", spec)
+	// `binary` and `unicode` are collation names rather than locales, so
+	// they never reach the BCP 47 parser. The binary specification is a
+	// bare language tag, so it takes no attribute.
+	if splitted[0] == "binary" {
+		if len(splitted) == 2 {
+			return nil, fmt.Errorf("COLLATE: collation '%s' is not valid: binary cannot be combined with a suffix", spec)
+		}
+		return value.StringValue(v), nil
 	}
-	tag := language.Make(splitted[0])
+	if splitted[0] != "unicode" {
+		if _, err := language.Parse(splitted[0]); err != nil {
+			return nil, fmt.Errorf("COLLATE: collation '%s' is not valid", spec)
+		}
+	}
 	caseInsensitive := false
 	if len(splitted) == 2 {
 		switch splitted[1] {
@@ -38,8 +47,6 @@ func COLLATE(v, spec string) (value.Value, error) {
 	// language tags reuse the same fold which is acceptable for
 	// the upstream Examples that exercise plain ASCII / Latin.
 	if caseInsensitive {
-		var buf collate.Buffer
-		_ = collate.New(tag, collate.IgnoreCase).KeyFromString(&buf, v)
 		return value.StringValue(strings.ToLower(v)), nil
 	}
 	return value.StringValue(v), nil

--- a/internal/functions/string/edit_distance.go
+++ b/internal/functions/string/edit_distance.go
@@ -1,6 +1,8 @@
 package string
 
 import (
+	"fmt"
+
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
@@ -69,15 +71,27 @@ func BindEditDistance(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	// An argument that is present but NULL is not an absent one: like
+	// the two values, max_distance propagates NULL.
+	hasMaxDistance := len(args) >= 3
+	if hasMaxDistance && args[2] == nil {
+		return nil, nil
+	}
+	var maxDistance int64
+	if hasMaxDistance {
+		maxDistance, err = args[2].ToInt64()
+		if err != nil {
+			return nil, err
+		}
+		if maxDistance < 0 {
+			return nil, fmt.Errorf("EDIT_DISTANCE: max_distance must be non-negative")
+		}
+	}
 	out, err := EDIT_DISTANCE(a, b)
 	if err != nil || out == nil {
 		return out, err
 	}
-	if len(args) >= 3 && args[2] != nil {
-		maxDistance, err := args[2].ToInt64()
-		if err != nil {
-			return nil, err
-		}
+	if hasMaxDistance {
 		got, err := out.ToInt64()
 		if err != nil {
 			return nil, err

--- a/internal/functions/string/lpad.go
+++ b/internal/functions/string/lpad.go
@@ -10,6 +10,9 @@ import (
 )
 
 func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (value.Value, error) {
+	if returnLength < 0 {
+		return nil, fmt.Errorf("LPAD: second argument (output size) cannot be negative")
+	}
 	retLen, err := helper.SafeInt(returnLength)
 	if err != nil {
 		return nil, err
@@ -20,6 +23,16 @@ func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if err != nil {
 			return nil, err
 		}
+		var p string
+		if pattern != nil {
+			p, err = pattern.ToString()
+			if err != nil {
+				return nil, err
+			}
+			if p == "" {
+				return nil, fmt.Errorf("LPAD: third argument (pad pattern) cannot be empty")
+			}
+		}
 		runes := []rune(s)
 		if len(runes) >= retLen {
 			return value.StringValue(string(runes[:retLen])), nil
@@ -29,10 +42,6 @@ func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if pattern == nil {
 			pat = []rune(strings.Repeat(" ", remainLen))
 		} else {
-			p, err := pattern.ToString()
-			if err != nil {
-				return nil, err
-			}
 			pat = []rune(p)
 			if remainLen-len(pat) > 0 {
 				// needs to repeat pattern
@@ -46,6 +55,16 @@ func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if err != nil {
 			return nil, err
 		}
+		var p []byte
+		if pattern != nil {
+			p, err = pattern.ToBytes()
+			if err != nil {
+				return nil, err
+			}
+			if len(p) == 0 {
+				return nil, fmt.Errorf("LPAD: third argument (pad pattern) cannot be empty")
+			}
+		}
 		if len(b) >= retLen {
 			return value.BytesValue(b[:retLen]), nil
 		}
@@ -54,17 +73,16 @@ func LPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if pattern == nil {
 			pat = bytes.Repeat([]byte{' '}, remainLen)
 		} else {
-			p, err := pattern.ToBytes()
-			if err != nil {
-				return nil, err
-			}
+			pat = p
 			if remainLen-len(p) > 0 {
 				// needs to repeat pattern
 				repeatNum := ((remainLen - len(p)) / len(p)) + 2
 				pat = bytes.Repeat(p, repeatNum)
 			}
 		}
-		return value.BytesValue(append(pat[:remainLen], b...)), nil
+		out := make([]byte, 0, retLen)
+		out = append(out, pat[:remainLen]...)
+		return value.BytesValue(append(out, b...)), nil
 	}
 	return nil, fmt.Errorf("LPAD: original value type is must be STRING or BYTES type")
 }

--- a/internal/functions/string/regexp_extract.go
+++ b/internal/functions/string/regexp_extract.go
@@ -34,13 +34,17 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if err != nil {
 			return nil, err
 		}
-		if pos >= len([]rune(v)) {
+		// Position 1 is a valid start for an empty value even though it
+		// has no first character, so an empty pattern still matches it.
+		atStartOfEmpty := v == "" && pos == 0
+		off, ok := charOffset(v, pos)
+		if !ok && !atStartOfEmpty {
 			return nil, nil
 		}
 		if err := checkCapturingGroups(re); err != nil {
 			return nil, err
 		}
-		rest := v[pos:]
+		rest := v[off:]
 		matches := re.FindAllStringSubmatchIndex(rest, occ)
 		if len(matches) < occ {
 			return nil, nil
@@ -55,7 +59,8 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if err != nil {
 			return nil, err
 		}
-		if pos >= len(v) {
+		atStartOfEmpty := len(v) == 0 && pos == 0
+		if pos >= len(v) && !atStartOfEmpty {
 			return nil, nil
 		}
 		if err := checkCapturingGroups(re); err != nil {

--- a/internal/functions/string/regexp_extract.go
+++ b/internal/functions/string/regexp_extract.go
@@ -41,7 +41,7 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if !ok && !atStartOfEmpty {
 			return nil, nil
 		}
-		if err := checkCapturingGroups(re); err != nil {
+		if err := checkExtractionGroups("REGEXP_EXTRACT", re); err != nil {
 			return nil, err
 		}
 		rest := v[off:]
@@ -63,7 +63,7 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if pos >= len(v) && !atStartOfEmpty {
 			return nil, nil
 		}
-		if err := checkCapturingGroups(re); err != nil {
+		if err := checkExtractionGroups("REGEXP_EXTRACT", re); err != nil {
 			return nil, err
 		}
 		rest := v[pos:]
@@ -78,18 +78,6 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		return value.BytesValue(rest[start:end]), nil
 	}
 	return nil, fmt.Errorf("REGEXP_EXTRACT: val argument must be STRING or BYTES")
-}
-
-// checkCapturingGroups rejects a pattern this function cannot use: it
-// returns one span per match, so at most one capturing group may decide
-// which span that is. The reference implementation reaches this check
-// only once it is about to match, so a value that yields no result at
-// all never gets here.
-func checkCapturingGroups(re *regexp.Regexp) error {
-	if re.NumSubexp() > 1 {
-		return fmt.Errorf("REGEXP_EXTRACT: regular expressions passed into extraction functions must not have more than 1 capturing group")
-	}
-	return nil
 }
 
 // extractedSpan picks the span REGEXP_EXTRACT returns for one match:

--- a/internal/functions/string/regexp_extract.go
+++ b/internal/functions/string/regexp_extract.go
@@ -37,12 +37,19 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if pos >= len([]rune(v)) {
 			return nil, nil
 		}
-		matches := re.FindAllStringSubmatch(v[pos:], occ)
+		if err := checkCapturingGroups(re); err != nil {
+			return nil, err
+		}
+		rest := v[pos:]
+		matches := re.FindAllStringSubmatchIndex(rest, occ)
 		if len(matches) < occ {
 			return nil, nil
 		}
-		match := matches[occ-1]
-		return value.StringValue(match[len(match)-1]), nil
+		start, end := extractedSpan(re, matches[occ-1])
+		if start < 0 {
+			return nil, nil
+		}
+		return value.StringValue(rest[start:end]), nil
 	case value.BytesValue:
 		v, err := val.ToBytes()
 		if err != nil {
@@ -51,14 +58,44 @@ func REGEXP_EXTRACT(val value.Value, expr string, position, occurrence int64) (v
 		if pos >= len(v) {
 			return nil, nil
 		}
-		matches := re.FindAllSubmatch(v[pos:], occ)
+		if err := checkCapturingGroups(re); err != nil {
+			return nil, err
+		}
+		rest := v[pos:]
+		matches := re.FindAllSubmatchIndex(rest, occ)
 		if len(matches) < occ {
 			return nil, nil
 		}
-		match := matches[occ-1]
-		return value.BytesValue(match[len(match)-1]), nil
+		start, end := extractedSpan(re, matches[occ-1])
+		if start < 0 {
+			return nil, nil
+		}
+		return value.BytesValue(rest[start:end]), nil
 	}
 	return nil, fmt.Errorf("REGEXP_EXTRACT: val argument must be STRING or BYTES")
+}
+
+// checkCapturingGroups rejects a pattern this function cannot use: it
+// returns one span per match, so at most one capturing group may decide
+// which span that is. The reference implementation reaches this check
+// only once it is about to match, so a value that yields no result at
+// all never gets here.
+func checkCapturingGroups(re *regexp.Regexp) error {
+	if re.NumSubexp() > 1 {
+		return fmt.Errorf("REGEXP_EXTRACT: regular expressions passed into extraction functions must not have more than 1 capturing group")
+	}
+	return nil
+}
+
+// extractedSpan picks the span REGEXP_EXTRACT returns for one match:
+// the capturing group when the pattern has one, the whole match
+// otherwise. A group that did not participate in the match has a
+// negative start, which the callers turn into NULL.
+func extractedSpan(re *regexp.Regexp, match []int) (int, int) {
+	if re.NumSubexp() == 1 {
+		return match[2], match[3]
+	}
+	return match[0], match[1]
 }
 
 var BindRegexpExtract = helper.ScalarN(func(args ...value.Value) (value.Value, error) {

--- a/internal/functions/string/regexp_extract_all.go
+++ b/internal/functions/string/regexp_extract_all.go
@@ -13,6 +13,9 @@ func REGEXP_EXTRACT_ALL(val value.Value, expr string) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := checkExtractionGroups("REGEXP_EXTRACT_ALL", re); err != nil {
+		return nil, err
+	}
 	switch val.(type) {
 	case value.StringValue:
 		v, err := val.ToString()

--- a/internal/functions/string/regexp_instr.go
+++ b/internal/functions/string/regexp_instr.go
@@ -3,6 +3,7 @@ package string
 import (
 	"fmt"
 	"regexp"
+	"unicode/utf8"
 
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
@@ -45,10 +46,12 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 		if err != nil {
 			return nil, err
 		}
-		if pos >= len([]rune(source)) {
+		off, ok := charOffset(source, pos)
+		if !ok {
 			return value.IntValue(0), nil
 		}
-		matches := re.FindAllStringSubmatchIndex(source[pos:], occ)
+		rest := source[off:]
+		matches := re.FindAllStringSubmatchIndex(rest, occ)
 		if len(matches) < occ {
 			return value.IntValue(0), nil
 		}
@@ -56,7 +59,7 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 		if len(match) <= occPos {
 			return value.IntValue(0), nil
 		}
-		return value.IntValue(pos + match[occPos] + 1), nil
+		return value.IntValue(pos + utf8.RuneCountInString(rest[:match[occPos]]) + 1), nil
 	case value.BytesValue:
 		source, err := sourceValue.ToBytes()
 		if err != nil {

--- a/internal/functions/string/regexp_instr.go
+++ b/internal/functions/string/regexp_instr.go
@@ -9,6 +9,16 @@ import (
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
+// reportedSpanIndex picks the match index REGEXP_INSTR reports on:
+// occurrencePos selects the start or the end of the span, and the span
+// is the capturing group when the pattern has one.
+func reportedSpanIndex(re *regexp.Regexp, occurrencePos int) int {
+	if re.NumSubexp() == 1 {
+		return occurrencePos + 2
+	}
+	return occurrencePos
+}
+
 func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occurrencePos int64) (value.Value, error) {
 	if position <= 0 {
 		return nil, fmt.Errorf("REGEXP_INSTR: unexpected position number. position must be positive number")
@@ -58,11 +68,12 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 		if len(matches) < occ {
 			return value.IntValue(0), nil
 		}
+		idx := reportedSpanIndex(re, occPos)
 		match := matches[occ-1]
-		if len(match) <= occPos {
+		if len(match) <= idx || match[idx] < 0 {
 			return value.IntValue(0), nil
 		}
-		return value.IntValue(pos + utf8.RuneCountInString(rest[:match[occPos]]) + 1), nil
+		return value.IntValue(pos + utf8.RuneCountInString(rest[:match[idx]]) + 1), nil
 	case value.BytesValue:
 		source, err := sourceValue.ToBytes()
 		if err != nil {
@@ -86,11 +97,12 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 		if len(matches) < occ {
 			return value.IntValue(0), nil
 		}
+		idx := reportedSpanIndex(re, occPos)
 		match := matches[occ-1]
-		if len(match) <= occPos {
+		if len(match) <= idx || match[idx] < 0 {
 			return value.IntValue(0), nil
 		}
-		return value.IntValue(pos + match[occPos] + 1), nil
+		return value.IntValue(pos + match[idx] + 1), nil
 	}
 	return nil, fmt.Errorf("REGEXP_INSTR: source value must be STRING or BYTES")
 }

--- a/internal/functions/string/regexp_instr.go
+++ b/internal/functions/string/regexp_instr.go
@@ -15,6 +15,9 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 	if occurrence <= 0 {
 		return nil, fmt.Errorf("REGEXP_INSTR: unexpected occurrence number. occurrence must be positive number")
 	}
+	if occurrencePos != 0 && occurrencePos != 1 {
+		return nil, fmt.Errorf("REGEXP_INSTR: invalid return_position_after_match: must be 0 or 1")
+	}
 	posInt, err := helper.SafeInt(position)
 	if err != nil {
 		return nil, err

--- a/internal/functions/string/regexp_instr.go
+++ b/internal/functions/string/regexp_instr.go
@@ -47,8 +47,11 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 			return nil, err
 		}
 		off, ok := charOffset(source, pos)
-		if !ok {
+		if !ok || expr == "" {
 			return value.IntValue(0), nil
+		}
+		if err := checkExtractionGroups("REGEXP_INSTR", re); err != nil {
+			return nil, err
 		}
 		rest := source[off:]
 		matches := re.FindAllStringSubmatchIndex(rest, occ)
@@ -73,8 +76,11 @@ func REGEXP_INSTR(sourceValue, exprValue value.Value, position, occurrence, occu
 		if err != nil {
 			return nil, err
 		}
-		if pos >= len(source) {
+		if pos >= len(source) || len(expr) == 0 {
 			return value.IntValue(0), nil
+		}
+		if err := checkExtractionGroups("REGEXP_INSTR", re); err != nil {
+			return nil, err
 		}
 		matches := re.FindAllSubmatchIndex(source[pos:], occ)
 		if len(matches) < occ {

--- a/internal/functions/string/regexp_replace.go
+++ b/internal/functions/string/regexp_replace.go
@@ -26,7 +26,7 @@ func REGEXP_REPLACE(val, exprValue, replacementValue value.Value) (value.Value, 
 		if err != nil {
 			return nil, err
 		}
-		normalized, err := normalizeReplacement(replacement)
+		normalized, err := normalizeReplacement(replacement, re.NumSubexp())
 		if err != nil {
 			return nil, err
 		}
@@ -48,7 +48,7 @@ func REGEXP_REPLACE(val, exprValue, replacementValue value.Value) (value.Value, 
 		if err != nil {
 			return nil, err
 		}
-		normalized, err := normalizeReplacement(string(replacement))
+		normalized, err := normalizeReplacement(string(replacement), re.NumSubexp())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/functions/string/repeat.go
+++ b/internal/functions/string/repeat.go
@@ -10,9 +10,8 @@ import (
 )
 
 func REPEAT(originalValue value.Value, repetitions int64) (value.Value, error) {
-	reps, err := helper.SafeInt(repetitions)
-	if err != nil {
-		return nil, err
+	if repetitions < 0 {
+		return nil, fmt.Errorf("REPEAT: second argument (repeat count) cannot be negative")
 	}
 	switch originalValue.(type) {
 	case value.StringValue:
@@ -20,9 +19,25 @@ func REPEAT(originalValue value.Value, repetitions int64) (value.Value, error) {
 		if err != nil {
 			return nil, err
 		}
+		// An empty value repeats to empty whatever the count is, so the
+		// count is never sized against the machine's int.
+		if v == "" {
+			return value.StringValue(""), nil
+		}
+		reps, err := helper.SafeInt(repetitions)
+		if err != nil {
+			return nil, err
+		}
 		return value.StringValue(strings.Repeat(v, reps)), nil
 	case value.BytesValue:
 		v, err := originalValue.ToBytes()
+		if err != nil {
+			return nil, err
+		}
+		if len(v) == 0 {
+			return value.BytesValue(nil), nil
+		}
+		reps, err := helper.SafeInt(repetitions)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/functions/string/rpad.go
+++ b/internal/functions/string/rpad.go
@@ -11,7 +11,7 @@ import (
 
 func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (value.Value, error) {
 	if returnLength < 0 {
-		return nil, fmt.Errorf("RPAD: unexpected returnLength value. returnLength must be positive number")
+		return nil, fmt.Errorf("RPAD: second argument (output size) cannot be negative")
 	}
 	retLen, err := helper.SafeInt(returnLength)
 	if err != nil {
@@ -23,6 +23,16 @@ func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if err != nil {
 			return nil, err
 		}
+		var p string
+		if pattern != nil {
+			p, err = pattern.ToString()
+			if err != nil {
+				return nil, err
+			}
+			if p == "" {
+				return nil, fmt.Errorf("RPAD: third argument (pad pattern) cannot be empty")
+			}
+		}
 		runes := []rune(v)
 		if len(runes) >= retLen {
 			return value.StringValue(string(runes[:retLen])), nil
@@ -32,10 +42,6 @@ func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if pattern == nil {
 			pat = []rune(strings.Repeat(" ", remainLen))
 		} else {
-			p, err := pattern.ToString()
-			if err != nil {
-				return nil, err
-			}
 			pat = []rune(p)
 			if remainLen-len(pat) > 0 {
 				// needs to repeat pattern
@@ -49,6 +55,16 @@ func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if err != nil {
 			return nil, err
 		}
+		var p []byte
+		if pattern != nil {
+			p, err = pattern.ToBytes()
+			if err != nil {
+				return nil, err
+			}
+			if len(p) == 0 {
+				return nil, fmt.Errorf("RPAD: third argument (pad pattern) cannot be empty")
+			}
+		}
 		if len(v) >= retLen {
 			return value.BytesValue(v[:retLen]), nil
 		}
@@ -57,17 +73,16 @@ func RPAD(originalValue value.Value, returnLength int64, pattern value.Value) (v
 		if pattern == nil {
 			pat = bytes.Repeat([]byte{' '}, remainLen)
 		} else {
-			p, err := pattern.ToBytes()
-			if err != nil {
-				return nil, err
-			}
+			pat = p
 			if remainLen-len(p) > 0 {
 				// needs to repeat pattern
 				repeatNum := ((remainLen - len(p)) / len(p)) + 2
 				pat = bytes.Repeat(p, repeatNum)
 			}
 		}
-		return value.BytesValue(append(v, pat[:remainLen]...)), nil
+		out := make([]byte, 0, retLen)
+		out = append(out, v...)
+		return value.BytesValue(append(out, pat[:remainLen]...)), nil
 	}
 	return nil, fmt.Errorf("RPAD: originalValue must be STRING or BYTES")
 }

--- a/internal/functions/string/string_helpers.go
+++ b/internal/functions/string/string_helpers.go
@@ -55,6 +55,22 @@ func normalizeReplacement(repl string) (string, error) {
 	return string(normalized), nil
 }
 
+// charOffset returns the byte offset of the n-th character of s,
+// counting from zero, and reports whether s has that many characters.
+// A `position` argument into a STRING is measured in characters while
+// the match indices Go returns are byte offsets, so the two units have
+// to be converted into each other rather than used interchangeably.
+func charOffset(s string, n int) (int, bool) {
+	count := 0
+	for i := range s {
+		if count == n {
+			return i, true
+		}
+		count++
+	}
+	return 0, false
+}
+
 // validCodePoint reports whether v is a code point CHR and
 // CODE_POINTS_TO_STRING accept: [0, 0xD7FF] or [0xE000, 0x10FFFF].
 // Everything else, surrogates included, is an error.

--- a/internal/functions/string/string_helpers.go
+++ b/internal/functions/string/string_helpers.go
@@ -29,7 +29,7 @@ func isDelim(v rune, delimiters []rune) bool {
 //
 // Go's Expand template instead spells group references "${d}" and uses
 // '$' as its sigil, so a literal '$' must be doubled to "$$".
-func normalizeReplacement(repl string) (string, error) {
+func normalizeReplacement(repl string, numGroups int) (string, error) {
 	var normalized []byte
 	for i := 0; i < len(repl); i++ {
 		switch c := repl[i]; c {
@@ -40,6 +40,12 @@ func normalizeReplacement(repl string) (string, error) {
 			next := repl[i+1]
 			switch {
 			case next >= '0' && next <= '9':
+				// Expand substitutes the empty string for a group the
+				// pattern does not have, so the reference
+				// implementation's check has to happen here.
+				if group := int(next - '0'); group > numGroups {
+					return "", fmt.Errorf("REGEXP_REPLACE: replacement refers to capturing group %d, but the regular expression has only %d", group, numGroups)
+				}
 				normalized = append(normalized, '$', '{', next, '}')
 			case next == '\\':
 				normalized = append(normalized, '\\')

--- a/internal/functions/string/string_helpers.go
+++ b/internal/functions/string/string_helpers.go
@@ -15,12 +15,14 @@ func isDelim(v rune, delimiters []rune) bool {
 // replacement string into the template syntax consumed by Go's
 // regexp.Expand (ReplaceAllString / ReplaceAll).
 //
-// The BigQuery replacement grammar (string_functions.md#regexp_replace)
-// is:
+// string_functions.md#regexp_replace documents \0 .. \9 as the text
+// captured by the corresponding group (\0 being the entire match) and
+// a backslash as the only character that needs escaping. The rest of
+// the grammar is stated by the reference implementation alone
+// (`regexp.cc:536`, `1f8aa33`):
 //
-//   - \0 .. \9  insert the text captured by the corresponding group,
-//     where \0 is the entire match. The index is a SINGLE digit; a
-//     following digit is a literal (e.g. \10 is group 1 then "0").
+//   - the group index is a SINGLE digit; a following digit is a
+//     literal (e.g. \10 is group 1 then "0").
 //   - \\        a literal backslash.
 //   - \ + other an error: "'\' must be followed by a digit or '\'".
 //   - every other byte, INCLUDING '$', is a literal.

--- a/internal/functions/string/string_helpers.go
+++ b/internal/functions/string/string_helpers.go
@@ -3,6 +3,7 @@ package string
 import (
 	"fmt"
 	"slices"
+	"unicode"
 )
 
 func isDelim(v rune, delimiters []rune) bool {
@@ -52,6 +53,13 @@ func normalizeReplacement(repl string) (string, error) {
 		}
 	}
 	return string(normalized), nil
+}
+
+// validCodePoint reports whether v is a code point CHR and
+// CODE_POINTS_TO_STRING accept: [0, 0xD7FF] or [0xE000, 0x10FFFF].
+// Everything else, surrogates included, is an error.
+func validCodePoint(v int64) bool {
+	return (v >= 0 && v <= 0xD7FF) || (v >= 0xE000 && v <= unicode.MaxRune)
 }
 
 var soundexMap = map[byte]byte{

--- a/internal/functions/string/string_helpers.go
+++ b/internal/functions/string/string_helpers.go
@@ -2,6 +2,7 @@ package string
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"unicode"
 )
@@ -53,6 +54,16 @@ func normalizeReplacement(repl string) (string, error) {
 		}
 	}
 	return string(normalized), nil
+}
+
+// checkExtractionGroups rejects a pattern the extraction functions
+// cannot use. They return one span per match, so at most one capturing
+// group may decide which span that is.
+func checkExtractionGroups(fn string, re *regexp.Regexp) error {
+	if re.NumSubexp() > 1 {
+		return fmt.Errorf("%s: regular expressions passed into extraction functions must not have more than 1 capturing group", fn)
+	}
+	return nil
 }
 
 // charOffset returns the byte offset of the n-th character of s,

--- a/testdata/specs/googlesql/functions/string/ascii.yaml
+++ b/testdata/specs/googlesql/functions/string/ascii.yaml
@@ -1,5 +1,11 @@
 spec: docs/specs/googlesql/functions/string/ascii.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md (ASCII
+# section, lines 600-626) for the Example. The STRING arm rejects input
+# whose first character is not ASCII while the BYTES arm accepts any
+# byte; those rows come from the GoogleSQL compliance fixtures
+# (`ascii` string/bytes cases, e.g. ASCII('ЖЩФ') is out of range and
+# ASCII(b'nbca\0\1cde') is 110).
 cases:
   - desc: uppercase letter
     sql: SELECT ASCII('A')
@@ -16,3 +22,28 @@ cases:
     expected:
       rows:
         - [0]
+  - desc: upstream example — first character, empty string and NULL
+    sql: SELECT ASCII('abcd') AS a, ASCII('a') AS b, ASCII('') AS c, ASCII(NULL) AS d
+    expected:
+      rows:
+        - [97, 97, 0, null]
+  - desc: leading space
+    sql: SELECT ASCII(' A')
+    expected:
+      rows:
+        - [32]
+  - desc: first character ASCII, remainder non-ASCII
+    sql: SELECT ASCII('nЖЩФ')
+    expected:
+      rows:
+        - [110]
+  - desc: BYTES accepts a non-ASCII byte
+    sql: SELECT ASCII(b'\xff')
+    expected:
+      rows:
+        - [255]
+  - desc: non-ASCII first character is an error
+    sql: SELECT ASCII('ЖЩФ')
+    expected:
+      error:
+        contains: not a structurally valid ASCII string

--- a/testdata/specs/googlesql/functions/string/chr.yaml
+++ b/testdata/specs/googlesql/functions/string/chr.yaml
@@ -1,5 +1,10 @@
 spec: docs/specs/googlesql/functions/string/chr.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md (CHR
+# section, lines 721-762) — both upstream Examples plus the documented
+# code-point range ("Each valid code point should fall within the range
+# of [0, 0xD7FF] and [0xE000, 0x10FFFF] ... If an invalid Unicode code
+# point is specified, an error is returned").
 cases:
   - desc: ascii uppercase
     sql: SELECT CHR(65)
@@ -11,3 +16,28 @@ cases:
     expected:
       rows:
         - ['a']
+  - desc: upstream example — Latin-1 and Cyrillic code points
+    sql: SELECT CHR(65) AS a, CHR(255) AS b, CHR(513) AS c, CHR(1024) AS d
+    expected:
+      rows:
+        - ['A', 'ÿ', 'ȁ', 'Ѐ']
+  - desc: upstream example — code point 0 is the empty string, NULL propagates
+    sql: SELECT CHR(97) AS a, CHR(0xF9B5) AS b, CHR(0) AS c, CHR(NULL) AS d
+    expected:
+      rows:
+        - ["a", "例", "", null]
+  - desc: negative code point is an error
+    sql: SELECT CHR(-1)
+    expected:
+      error:
+        contains: Invalid codepoint
+  - desc: code point above the Unicode maximum is an error
+    sql: SELECT CHR(1114112)
+    expected:
+      error:
+        contains: Invalid codepoint
+  - desc: surrogate code point is an error
+    sql: SELECT CHR(55296)
+    expected:
+      error:
+        contains: Invalid codepoint

--- a/testdata/specs/googlesql/functions/string/code_points_to_string.yaml
+++ b/testdata/specs/googlesql/functions/string/code_points_to_string.yaml
@@ -1,8 +1,67 @@
 spec: docs/specs/googlesql/functions/string/code_points_to_string.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md
+# (CODE_POINTS_TO_STRING section, lines 832-914) — every upstream
+# Example. The code-point range is the one CHR documents (lines
+# 729-733): [0, 0xD7FF] and [0xE000, 0x10FFFF], anything else is an
+# error.
 cases:
   - desc: code_points_to_string basic behaviour
     sql: SELECT CODE_POINTS_TO_STRING([72, 101])
     expected:
       rows:
         - ['He']
+  - desc: upstream example — Latin-1 and Cyrillic code points
+    sql: SELECT CODE_POINTS_TO_STRING([65, 255, 513, 1024])
+    expected:
+      rows:
+        - ['AÿȁЀ']
+  - desc: upstream example — code point 0 contributes nothing
+    sql: SELECT CODE_POINTS_TO_STRING([97, 0, 0xF9B5])
+    expected:
+      rows:
+        - ['a例']
+  - desc: upstream example — a NULL element makes the result NULL
+    sql: SELECT CODE_POINTS_TO_STRING([65, 255, NULL, 1024])
+    expected:
+      rows:
+        - [null]
+  - desc: upstream example — letter frequency
+    sql: |-
+      WITH Words AS (
+        SELECT word
+        FROM UNNEST(['foo', 'bar', 'baz', 'giraffe', 'llama']) AS word
+      )
+      SELECT
+        CODE_POINTS_TO_STRING([code_point]) AS letter,
+        COUNT(*) AS letter_count
+      FROM Words,
+        UNNEST(TO_CODE_POINTS(word)) AS code_point
+      GROUP BY 1
+      ORDER BY 2 DESC
+    expected:
+      # ORDER BY letter_count alone leaves the letters within one count
+      # group in an unspecified order.
+      unordered: true
+      rows:
+        - ['a', 5]
+        - ['f', 3]
+        - ['r', 2]
+        - ['b', 2]
+        - ['l', 2]
+        - ['o', 2]
+        - ['g', 1]
+        - ['z', 1]
+        - ['e', 1]
+        - ['m', 1]
+        - ['i', 1]
+  - desc: negative code point is an error
+    sql: SELECT CODE_POINTS_TO_STRING([-1])
+    expected:
+      error:
+        contains: Invalid codepoint
+  - desc: code point above the Unicode maximum is an error
+    sql: SELECT CODE_POINTS_TO_STRING([1114112])
+    expected:
+      error:
+        contains: Invalid codepoint

--- a/testdata/specs/googlesql/functions/string/collate.yaml
+++ b/testdata/specs/googlesql/functions/string/collate.yaml
@@ -27,3 +27,45 @@ cases:
     expected:
       rows:
         - [false]
+  # docs/third_party/googlesql-docs/collation-concepts.md enumerates the
+  # allowed language tags: a CLDR locale string, `und`, `unicode` or
+  # `binary`, optionally suffixed with `:ci` / `:cs`. Anything else is
+  # not a collation specification.
+  - desc: empty specification removes the collation
+    sql: SELECT COLLATE('abc', '')
+    expected:
+      rows:
+        - ['abc']
+  - desc: binary language tag is accepted
+    sql: SELECT COLLATE('abc', 'binary')
+    expected:
+      rows:
+        - ['abc']
+  - desc: unknown language tag is an error
+    sql: SELECT COLLATE('abc', 'invalid')
+    expected:
+      error:
+        contains: is not valid
+  # The binary specification is a bare language tag
+  # (collation-concepts.md#binary_collation), so a suffix on it is not a
+  # collation specification: reference implementation `collator.cc:93`
+  # (`1f8aa33`), "binary cannot be combined with a suffix".
+  - desc: binary language tag with an attribute is an error
+    sql: SELECT COLLATE('ABC', 'binary:ci')
+    expected:
+      error:
+        contains: binary
+  # `unicode:ci` is identical to `und:ci` and plain `unicode` to
+  # `binary`, which orders by code point (collation-concepts.md#
+  # unicode_collation), so these two are the upstream `und:ci` Example
+  # and its uncollated counterpart under the other spelling.
+  - desc: unicode language tag keeps the case-insensitive attribute
+    sql: SELECT COLLATE('a', 'unicode:ci') < COLLATE('Z', 'unicode:ci')
+    expected:
+      rows:
+        - [true]
+  - desc: unicode language tag is case-sensitive by default
+    sql: SELECT COLLATE('a', 'unicode') < COLLATE('Z', 'unicode')
+    expected:
+      rows:
+        - [false]

--- a/testdata/specs/googlesql/functions/string/edit_distance.yaml
+++ b/testdata/specs/googlesql/functions/string/edit_distance.yaml
@@ -1,8 +1,45 @@
 spec: docs/specs/googlesql/functions/string/edit_distance.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md
+# (EDIT_DISTANCE section, lines 1060-1149) — every upstream Example.
+# max_distance is documented as "an INT64 value that's greater than or
+# equal to zero", so a negative value is an error.
 cases:
   - desc: edit_distance basic behaviour
     sql: SELECT EDIT_DISTANCE("kitten", "sitting")
     expected:
       rows:
         - [3]
+  - desc: upstream example — one differing character
+    sql: SELECT EDIT_DISTANCE('a', 'b')
+    expected:
+      rows:
+        - [1]
+  - desc: upstream example — two differing characters
+    sql: SELECT EDIT_DISTANCE('aa', 'b')
+    expected:
+      rows:
+        - [2]
+  - desc: upstream example — only the first character differs
+    sql: SELECT EDIT_DISTANCE('aa', 'ba')
+    expected:
+      rows:
+        - [1]
+  - desc: upstream example — max_distance caps the result
+    sql: SELECT EDIT_DISTANCE('abcdefg', 'a', max_distance => 2)
+    expected:
+      rows:
+        - [2]
+  - desc: negative max_distance is an error
+    sql: SELECT EDIT_DISTANCE('abc', 'abd', max_distance => -1)
+    expected:
+      error:
+        contains: max_distance
+  # An explicit NULL argument is not an absent one: the compliance
+  # fixtures give EDIT_DISTANCE('abc', 'a', NULL) as NULL, the same
+  # NULL propagation the two value arguments have.
+  - desc: NULL max_distance propagates
+    sql: SELECT EDIT_DISTANCE('abcdefg', 'a', max_distance => CAST(NULL AS INT64))
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/string/lpad.yaml
+++ b/testdata/specs/googlesql/functions/string/lpad.yaml
@@ -1,5 +1,9 @@
 spec: docs/specs/googlesql/functions/string/lpad.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md (LPAD
+# section, lines 2435-2519) — every upstream Example plus the two
+# documented error conditions ("This function returns an error if:
+# + return_length is negative + pattern is empty").
 cases:
   - desc: pad to length 5
     sql: SELECT LPAD('hi', 5, '*')
@@ -11,3 +15,89 @@ cases:
     expected:
       rows:
         - ['hi']
+  - desc: upstream example — default pattern is a blank space
+    sql: SELECT FORMAT('%T', LPAD('c', 5))
+    expected:
+      rows:
+        - ['"    c"']
+  - desc: upstream example — single-character pattern
+    sql: SELECT LPAD('b', 5, 'a')
+    expected:
+      rows:
+        - ['aaaab']
+  - desc: upstream example — repeated pattern truncated to the gap
+    sql: SELECT LPAD('abc', 10, 'ghd')
+    expected:
+      rows:
+        - ['ghdghdgabc']
+  - desc: upstream example — return_length shorter than the value truncates
+    sql: SELECT LPAD('abc', 2, 'd')
+    expected:
+      rows:
+        - ['ab']
+  - desc: upstream example — BYTES value and pattern
+    sql: SELECT FORMAT('%T', LPAD(b'abc', 10, b'ghd'))
+    expected:
+      rows:
+        - ['b"ghdghdgabc"']
+  # Same rule as the BYTES Example above, with the pattern longer than
+  # the gap it fills: the pattern is truncated, not repeated. Values
+  # from the GoogleSQL compliance fixtures (padding function tests).
+  - desc: BYTES pattern longer than the remaining gap
+    sql: SELECT FORMAT('%T', LPAD(b'abc', 5, b'defgh'))
+    expected:
+      rows:
+        - ['b"deabc"']
+  - desc: STRING pattern longer than the remaining gap
+    sql: SELECT LPAD('abc', 5, 'defgh')
+    expected:
+      rows:
+        - ['deabc']
+  - desc: empty value padded with a repeated pattern
+    sql: SELECT LPAD('', 7, 'def')
+    expected:
+      rows:
+        - ['defdefd']
+  - desc: NULL value propagates
+    sql: SELECT LPAD(CAST(NULL AS STRING), 5, '*')
+    expected:
+      rows:
+        - [null]
+  - desc: negative return_length is an error
+    sql: SELECT LPAD('abc', -1)
+    expected:
+      error:
+        contains: cannot be negative
+  - desc: negative return_length with a pattern is an error
+    sql: SELECT LPAD('abc', -1, 'x')
+    expected:
+      error:
+        contains: cannot be negative
+  - desc: negative return_length on BYTES is an error
+    sql: SELECT LPAD(b'abc', -1, b'x')
+    expected:
+      error:
+        contains: cannot be negative
+  - desc: empty pattern is an error
+    sql: SELECT LPAD('abc', 5, '')
+    expected:
+      error:
+        contains: cannot be empty
+  - desc: empty BYTES pattern is an error
+    sql: SELECT LPAD(b'abc', 5, b'')
+    expected:
+      error:
+        contains: cannot be empty
+  # Source: reference implementation string.cc:1440 (1f8aa33) — the pad
+  # arguments are verified before the output_size <= input length path,
+  # so a value that only needs truncating is rejected too.
+  - desc: empty pattern is an error when the value is truncated
+    sql: SELECT LPAD('abc', 2, '')
+    expected:
+      error:
+        contains: cannot be empty
+  - desc: empty BYTES pattern is an error when the value is unchanged
+    sql: SELECT LPAD(b'abc', 3, b'')
+    expected:
+      error:
+        contains: cannot be empty

--- a/testdata/specs/googlesql/functions/string/regexp_extract.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_extract.yaml
@@ -1,8 +1,80 @@
 spec: docs/specs/googlesql/functions/string/regexp_extract.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md
+# (REGEXP_EXTRACT section, lines 2880-2990) — every upstream Example
+# plus the documented error condition ("Returns an error if: ... The
+# regular expression has more than one capturing group").
 cases:
   - desc: extract first digit run
     sql: SELECT REGEXP_EXTRACT("abc123def", "[0-9]+")
     expected:
       rows:
         - ["123"]
+  - desc: upstream example — user name
+    sql: SELECT REGEXP_EXTRACT('foo@example.com', r'^[a-zA-Z0-9_.+-]+')
+    expected:
+      rows:
+        - ['foo']
+  - desc: upstream example — capturing group returns the group
+    sql: |-
+      SELECT REGEXP_EXTRACT('foo@example.com', r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.([a-zA-Z0-9-.]+$)')
+    expected:
+      rows:
+        - ['com']
+  - desc: upstream example — group participation decides the result
+    sql: |-
+      SELECT
+        REGEXP_EXTRACT('ab', '.b') AS result_a,
+        REGEXP_EXTRACT('ab', '(.)b') AS result_b,
+        REGEXP_EXTRACT('xyztb', '(.)+b') AS result_c,
+        REGEXP_EXTRACT('ab', '(z)?b') AS result_d
+    expected:
+      rows:
+        - ['ab', 'a', 't', null]
+  - desc: upstream example — position and occurrence
+    sql: |-
+      WITH example AS
+      (SELECT 'Hello Helloo and Hellooo' AS value, 'H?ello+' AS regex, 1 as position,
+      1 AS occurrence UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 1, 2 UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 1, 3 UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 1, 4 UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 2, 1 UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 3, 1 UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 3, 2 UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 3, 3 UNION ALL
+      SELECT 'Hello Helloo and Hellooo', 'H?ello+', 20, 1 UNION ALL
+      SELECT 'cats&dogs&rabbits' ,'\\w+&', 1, 2 UNION ALL
+      SELECT 'cats&dogs&rabbits', '\\w+&', 2, 3
+      )
+      SELECT value, regex, position, occurrence, REGEXP_EXTRACT(value, regex,
+      position, occurrence) AS regexp_value FROM example
+    expected:
+      # UNION ALL without ORDER BY leaves the row order unspecified.
+      unordered: true
+      rows:
+        - ['Hello Helloo and Hellooo', 'H?ello+', 1, 1, 'Hello']
+        - ['Hello Helloo and Hellooo', 'H?ello+', 1, 2, 'Helloo']
+        - ['Hello Helloo and Hellooo', 'H?ello+', 1, 3, 'Hellooo']
+        - ['Hello Helloo and Hellooo', 'H?ello+', 1, 4, null]
+        - ['Hello Helloo and Hellooo', 'H?ello+', 2, 1, 'ello']
+        - ['Hello Helloo and Hellooo', 'H?ello+', 3, 1, 'Helloo']
+        - ['Hello Helloo and Hellooo', 'H?ello+', 3, 2, 'Hellooo']
+        - ['Hello Helloo and Hellooo', 'H?ello+', 3, 3, null]
+        - ['Hello Helloo and Hellooo', 'H?ello+', 20, 1, null]
+        - ['cats&dogs&rabbits', '\w+&', 1, 2, 'dogs&']
+        - ['cats&dogs&rabbits', '\w+&', 2, 3, null]
+  - desc: more than one capturing group is an error
+    sql: SELECT REGEXP_EXTRACT('abc', r'(a)(b)')
+    expected:
+      error:
+        contains: capturing group
+  # The reference implementation validates the pattern where it starts
+  # matching, so a position past the end returns NULL and the pattern is
+  # never looked at (`regexp.cc:117`, `1f8aa33`). Verified against
+  # BigQuery.
+  - desc: a position past the end returns NULL without reading the pattern
+    sql: SELECT REGEXP_EXTRACT('abc', r'(a)(b)', 4)
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/string/regexp_extract.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_extract.yaml
@@ -78,3 +78,39 @@ cases:
     expected:
       rows:
         - [null]
+  # Source: compliance fixtures (regexp function tests) — `position`
+  # counts characters in a STRING.
+  - desc: position counts characters in a STRING
+    sql: SELECT REGEXP_EXTRACT('щцф', '.{2}', 2)
+    expected:
+      rows:
+        - ['цф']
+  - desc: position past the last character returns NULL
+    sql: SELECT REGEXP_EXTRACT('щцф', '.{2}', 3)
+    expected:
+      rows:
+        - [null]
+  - desc: occurrence counts from a character position
+    sql: SELECT REGEXP_EXTRACT('щцфщфф', 'щ(.).', 1, 2)
+    expected:
+      rows:
+        - ['ф']
+  # An empty value has no first character, but position 1 is still a
+  # valid start for it (`regexp.cc:117`, `1f8aa33`; compliance fixtures
+  # REGEXP_EXTRACT("", "") and its BYTES twin). Verified against
+  # BigQuery.
+  - desc: an empty pattern matches an empty value
+    sql: SELECT REGEXP_EXTRACT('', '')
+    expected:
+      rows:
+        - ['']
+  - desc: an empty pattern matches an empty BYTES value
+    sql: SELECT TO_HEX(REGEXP_EXTRACT(b'', b''))
+    expected:
+      rows:
+        - ['']
+  - desc: a position past the end of an empty value returns NULL
+    sql: SELECT REGEXP_EXTRACT('', '', 2)
+    expected:
+      rows:
+        - [null]

--- a/testdata/specs/googlesql/functions/string/regexp_extract_all.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_extract_all.yaml
@@ -1,8 +1,48 @@
 spec: docs/specs/googlesql/functions/string/regexp_extract_all.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md
+# (REGEXP_EXTRACT_ALL section, lines 3264-3305) — the upstream Example
+# and the documented error conditions ("Returns an error if: ... The
+# regular expression has more than one capturing group"). The remaining
+# rows are compliance fixtures for this function.
 cases:
   - desc: capture-group extraction returns digits
-    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('a1 b2 c3', r'(\w)(\d)'))
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('a1 b2 c3', r'\w(\d)'))
     expected:
       rows:
         - ['["1","2","3"]']
+  - desc: upstream example — every quoted call
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('Try `func(x)` or `func(y)`', '`(.+?)`'))
+    expected:
+      rows:
+        - ['["func(x)","func(y)"]']
+  - desc: no capturing group returns whole matches
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('abc', '.'))
+    expected:
+      rows:
+        - ['["a","b","c"]']
+  - desc: whole matches are counted in characters
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('щцф', '.'))
+    expected:
+      rows:
+        - ['["щ","ц","ф"]']
+  - desc: a repeated capturing group keeps its last match
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('abcd', r'a(bc)*'))
+    expected:
+      rows:
+        - ['["bc"]']
+  - desc: no match returns an empty array
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('abcdef', 'ac.*e.'))
+    expected:
+      rows:
+        - ['[]']
+  - desc: two capturing groups are an error
+    sql: SELECT REGEXP_EXTRACT_ALL('abc', r'(a)(b)')
+    expected:
+      error:
+        contains: capturing group
+  - desc: nested capturing groups are an error
+    sql: SELECT REGEXP_EXTRACT_ALL('abc', r'((a))')
+    expected:
+      error:
+        contains: capturing group

--- a/testdata/specs/googlesql/functions/string/regexp_extract_all.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_extract_all.yaml
@@ -36,6 +36,28 @@ cases:
     expected:
       rows:
         - ['[]']
+  # A capturing group that did not participate in the match contributes
+  # an empty string, not NULL: the iterator hands the group's empty
+  # span to the caller (`regexp.cc:192`, `1f8aa33`), which builds a
+  # value from it without asking whether the group took part
+  # (`reference_impl/function.cc:1422`). Only the single-value
+  # REGEXP_EXTRACT distinguishes the two. Source: compliance fixtures
+  # (`functions_testlib_regex.cc:307-309`).
+  - desc: a group that did not participate contributes an empty string
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('', r'(abc)?'))
+    expected:
+      rows:
+        - ['[""]']
+  - desc: a group that captured nothing contributes an empty string
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('', r'()'))
+    expected:
+      rows:
+        - ['[""]']
+  - desc: a pattern that does not match at all returns an empty array
+    sql: SELECT TO_JSON_STRING(REGEXP_EXTRACT_ALL('', r'(abc)'))
+    expected:
+      rows:
+        - ['[]']
   - desc: two capturing groups are an error
     sql: SELECT REGEXP_EXTRACT_ALL('abc', r'(a)(b)')
     expected:

--- a/testdata/specs/googlesql/functions/string/regexp_instr.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_instr.yaml
@@ -1,8 +1,80 @@
 spec: docs/specs/googlesql/functions/string/regexp_instr.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md
+# (REGEXP_INSTR section, lines 3306-3413) — every upstream Example plus
+# the documented error conditions ("Returns an error if: + position is
+# 0 or negative. + occurrence is 0 or negative. + occurrence_position
+# is neither 0 nor 1.").
 cases:
   - desc: regexp_instr basic behaviour
     sql: SELECT REGEXP_INSTR("hello", "l")
     expected:
       rows:
         - [3]
+  - desc: upstream example — default position and occurrence
+    sql: |-
+      SELECT
+        REGEXP_INSTR('ab@cd-ef',  '@[^-]*') AS instr_a,
+        REGEXP_INSTR('ab@d-ef',   '@[^-]*') AS instr_b,
+        REGEXP_INSTR('abc@cd-ef', '@[^-]*') AS instr_c,
+        REGEXP_INSTR('abc-ef',    '@[^-]*') AS instr_d
+    expected:
+      rows:
+        - [3, 3, 4, 0]
+  - desc: upstream example — explicit position
+    sql: |-
+      SELECT
+        REGEXP_INSTR('a@cd-ef b@cd-ef', '@[^-]*', 1) AS instr_a,
+        REGEXP_INSTR('a@cd-ef b@cd-ef', '@[^-]*', 2) AS instr_b,
+        REGEXP_INSTR('a@cd-ef b@cd-ef', '@[^-]*', 3) AS instr_c,
+        REGEXP_INSTR('a@cd-ef b@cd-ef', '@[^-]*', 4) AS instr_d
+    expected:
+      rows:
+        - [2, 2, 10, 10]
+  - desc: upstream example — explicit occurrence
+    sql: |-
+      SELECT
+        REGEXP_INSTR('a@cd-ef b@cd-ef c@cd-ef', '@[^-]*', 1, 1) AS instr_a,
+        REGEXP_INSTR('a@cd-ef b@cd-ef c@cd-ef', '@[^-]*', 1, 2) AS instr_b,
+        REGEXP_INSTR('a@cd-ef b@cd-ef c@cd-ef', '@[^-]*', 1, 3) AS instr_c
+    expected:
+      rows:
+        - [2, 10, 18]
+  - desc: upstream example — occurrence_position selects start or end+1
+    sql: |-
+      SELECT
+        REGEXP_INSTR('a@cd-ef', '@[^-]*', 1, 1, 0) AS instr_a,
+        REGEXP_INSTR('a@cd-ef', '@[^-]*', 1, 1, 1) AS instr_b
+    expected:
+      rows:
+        - [2, 5]
+  - desc: no match returns 0
+    sql: SELECT REGEXP_INSTR('abc', 'z')
+    expected:
+      rows:
+        - [0]
+  - desc: NULL position propagates
+    sql: SELECT REGEXP_INSTR('abc', 'b', CAST(NULL AS INT64))
+    expected:
+      rows:
+        - [null]
+  - desc: position 0 is an error
+    sql: SELECT REGEXP_INSTR('abc', 'b', 0)
+    expected:
+      error:
+        contains: position
+  - desc: occurrence 0 is an error
+    sql: SELECT REGEXP_INSTR('abc', 'b', 1, 0)
+    expected:
+      error:
+        contains: occurrence
+  - desc: negative occurrence_position is an error
+    sql: SELECT REGEXP_INSTR('abc', 'b', 1, 1, -1)
+    expected:
+      error:
+        contains: return_position_after_match
+  - desc: occurrence_position other than 0 or 1 is an error
+    sql: SELECT REGEXP_INSTR('abc', 'b', 1, 1, 2)
+    expected:
+      error:
+        contains: return_position_after_match

--- a/testdata/specs/googlesql/functions/string/regexp_instr.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_instr.yaml
@@ -73,6 +73,30 @@ cases:
     expected:
       error:
         contains: return_position_after_match
+  # A STRING is measured in characters and a BYTES value in bytes, so
+  # the position this function returns — and the `position` it takes —
+  # follow the same units. The end-of-match row is the documented
+  # "LENGTH(source_value) + 1" case.
+  - desc: the returned position counts characters
+    sql: SELECT REGEXP_INSTR('é@x', '@')
+    expected:
+      rows:
+        - [2]
+  - desc: the position argument counts characters
+    sql: SELECT REGEXP_INSTR('éé@', '@', 2)
+    expected:
+      rows:
+        - [3]
+  - desc: end of the match at the end of the value is LENGTH + 1
+    sql: SELECT REGEXP_INSTR('é@', '@', 1, 1, 1)
+    expected:
+      rows:
+        - [3]
+  - desc: BYTES positions count bytes
+    sql: SELECT REGEXP_INSTR(b'éa', b'a')
+    expected:
+      rows:
+        - [3]
   - desc: occurrence_position other than 0 or 1 is an error
     sql: SELECT REGEXP_INSTR('abc', 'b', 1, 1, 2)
     expected:

--- a/testdata/specs/googlesql/functions/string/regexp_instr.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_instr.yaml
@@ -126,6 +126,43 @@ cases:
     expected:
       rows:
         - [3]
+  # Source: reference implementation `regexp.h:276` (`1f8aa33`) — "If
+  # the regular expression contains a capturing group, the function
+  # returns the position for the capturing group", not for the whole
+  # match. The values below are the compliance fixtures' rows.
+  - desc: a capturing group decides the reported position
+    sql: SELECT REGEXP_INSTR('abc', r'a(b)c')
+    expected:
+      rows:
+        - [2]
+  - desc: a capturing group in the middle of a longer match
+    sql: SELECT REGEXP_INSTR('abcdef', r'a(.c.*)f')
+    expected:
+      rows:
+        - [2]
+  - desc: the group position counts characters
+    sql: SELECT REGEXP_INSTR('щцф', r'щ(.).')
+    expected:
+      rows:
+        - [2]
+  - desc: a capturing group on BYTES operands
+    sql: SELECT REGEXP_INSTR(b'abcdef', rb'a(.c.*)f')
+    expected:
+      rows:
+        - [2]
+  - desc: a capturing group after an explicit position
+    sql: SELECT REGEXP_INSTR(b'agbfagde', rb'ag(..)', 2)
+    expected:
+      rows:
+        - [7]
+  # A group that did not participate has no position of its own, so the
+  # result is 0 even though the pattern matched (`regexp.cc:419`,
+  # `1f8aa33`). Verified against BigQuery.
+  - desc: a capturing group that did not participate returns 0
+    sql: SELECT REGEXP_INSTR('abc', r'(z)?b')
+    expected:
+      rows:
+        - [0]
   - desc: occurrence_position other than 0 or 1 is an error
     sql: SELECT REGEXP_INSTR('abc', 'b', 1, 1, 2)
     expected:

--- a/testdata/specs/googlesql/functions/string/regexp_instr.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_instr.yaml
@@ -73,6 +73,35 @@ cases:
     expected:
       error:
         contains: return_position_after_match
+  # "Returns 0 if: ... The regular expression is empty." and "Returns
+  # an error if: ... The regular expression has more than one capturing
+  # group." — the same two rows the compliance fixtures carry for this
+  # function.
+  - desc: an empty regular expression returns 0
+    sql: SELECT REGEXP_INSTR('abcdef', '')
+    expected:
+      rows:
+        - [0]
+  - desc: an empty BYTES regular expression returns 0
+    sql: SELECT REGEXP_INSTR(b'abcdef', b'')
+    expected:
+      rows:
+        - [0]
+  - desc: two capturing groups are an error
+    sql: SELECT REGEXP_INSTR('abc', r'(a)(b)')
+    expected:
+      error:
+        contains: capturing group
+  - desc: nested capturing groups are an error
+    sql: SELECT REGEXP_INSTR('abc', r'((a))')
+    expected:
+      error:
+        contains: capturing group
+  - desc: two capturing groups in a BYTES pattern are an error
+    sql: SELECT REGEXP_INSTR(b'abc', rb'(a)(b)')
+    expected:
+      error:
+        contains: capturing group
   # A STRING is measured in characters and a BYTES value in bytes, so
   # the position this function returns — and the `position` it takes —
   # follow the same units. The end-of-match row is the documented

--- a/testdata/specs/googlesql/functions/string/regexp_replace.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_replace.yaml
@@ -31,8 +31,10 @@ cases:
     expected:
       rows:
         - ["a[bc]"]
-  # Backreferences are a single digit: \10 is group 1 followed by a
-  # literal '0', not group 10.
+  # Source: reference implementation `regexp.cc:536` (`1f8aa33`) — the
+  # group index is read one digit at a time, so \10 is group 1 followed
+  # by a literal '0', not group 10. string_functions.md documents only
+  # \0 to \9 and says nothing about the two-digit form.
   - desc: single-digit backreference then literal digit
     sql: |
       SELECT REGEXP_REPLACE("abcdefghijk", r"(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)", r"\10")
@@ -46,8 +48,10 @@ cases:
     expected:
       rows:
         - ["a\\c"]
-  # '$' is an ordinary literal in a BigQuery replacement (unlike RE2's
-  # own Expand syntax, where '$' is the group sigil).
+  # Source: reference implementation `regexp.cc:536` (`1f8aa33`) — only
+  # a backslash is special in a replacement, so '$' is an ordinary
+  # literal (unlike RE2's own Expand syntax, where it is the group
+  # sigil).
   - desc: literal dollar sign in replacement
     sql: |
       SELECT REGEXP_REPLACE("abc", r"(b)", r"p$q")
@@ -60,8 +64,9 @@ cases:
     expected:
       rows:
         - ["a${1}c"]
-  # A backslash must be followed by a digit or another backslash;
-  # anything else is an error.
+  # Source: reference implementation `regexp.cc:536` (`1f8aa33`) — a
+  # backslash must be followed by a digit or another backslash;
+  # anything else is "Invalid REGEXP_REPLACE pattern".
   - desc: backslash followed by a non-digit is an error
     sql: |
       SELECT REGEXP_REPLACE("abc", r"(b)", r"\q")

--- a/testdata/specs/googlesql/functions/string/regexp_replace.yaml
+++ b/testdata/specs/googlesql/functions/string/regexp_replace.yaml
@@ -73,3 +73,19 @@ cases:
     expected:
       error:
         contains: "must be followed by a digit"
+  # Source: reference implementation `regexp.cc:469` (`1f8aa33`), which
+  # checks the replacement against the pattern before rewriting; the
+  # rule itself is RE2's CheckRewriteString. The second row is the
+  # compliance fixtures' REGEXP_REPLACE("", "", "\\1").
+  - desc: a backreference past the last group is an error
+    sql: |
+      SELECT REGEXP_REPLACE("abc", r"b(.)", r"X\2")
+    expected:
+      error:
+        contains: capturing group
+  - desc: a backreference with no group at all is an error
+    sql: |
+      SELECT REGEXP_REPLACE("", "", r"\1")
+    expected:
+      error:
+        contains: capturing group

--- a/testdata/specs/googlesql/functions/string/repeat.yaml
+++ b/testdata/specs/googlesql/functions/string/repeat.yaml
@@ -1,5 +1,9 @@
 spec: docs/specs/googlesql/functions/string/repeat.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md (REPEAT
+# section, lines 3554-3603) — every upstream Example plus the
+# documented error condition ("This function returns an error if the
+# repetitions value is negative").
 cases:
   - desc: repeat thrice
     sql: SELECT REPEAT('ab', 3)
@@ -8,6 +12,46 @@ cases:
         - ['ababab']
   - desc: zero repetitions
     sql: SELECT REPEAT('ab', 0)
+    expected:
+      rows:
+        - ['']
+  - desc: upstream example — repeat thrice
+    sql: SELECT REPEAT('abc', 3)
+    expected:
+      rows:
+        - ['abcabcabc']
+  - desc: upstream example — NULL repetitions
+    sql: SELECT REPEAT('abc', NULL)
+    expected:
+      rows:
+        - [null]
+  - desc: upstream example — NULL value
+    sql: SELECT REPEAT(CAST(NULL AS STRING), 3)
+    expected:
+      rows:
+        - [null]
+  # NULL is propagated before the range check, so a NULL value with a
+  # negative count is NULL rather than an error.
+  - desc: NULL value with a negative count propagates
+    sql: SELECT REPEAT(CAST(NULL AS STRING), -1)
+    expected:
+      rows:
+        - [null]
+  - desc: negative repetitions is an error
+    sql: SELECT REPEAT('ab', -1)
+    expected:
+      error:
+        contains: cannot be negative
+  - desc: negative repetitions on BYTES is an error
+    sql: SELECT REPEAT(b'ab', -1)
+    expected:
+      error:
+        contains: cannot be negative
+  # Source: reference implementation `string.cc:1631` (`1f8aa33`) — an
+  # empty value produces an empty result whatever the count is, so the
+  # count is never sized. Compliance fixture REPEAT("", 2147483648).
+  - desc: an empty value repeats to empty for any count
+    sql: SELECT REPEAT('', 2147483648)
     expected:
       rows:
         - ['']

--- a/testdata/specs/googlesql/functions/string/rpad.yaml
+++ b/testdata/specs/googlesql/functions/string/rpad.yaml
@@ -1,8 +1,93 @@
 spec: docs/specs/googlesql/functions/string/rpad.md
 dialect: googlesql
+# Source: docs/third_party/googlesql-docs/string_functions.md (RPAD
+# section, lines 3729-3814) — every upstream Example plus the two
+# documented error conditions ("This function returns an error if:
+# + return_length is negative + pattern is empty").
 cases:
   - desc: pad to length 5
     sql: SELECT RPAD('hi', 5, '*')
     expected:
       rows:
         - ['hi***']
+  - desc: upstream example — default pattern is a blank space
+    sql: SELECT FORMAT('%T', RPAD('c', 5))
+    expected:
+      rows:
+        - ['"c    "']
+  - desc: upstream example — single-character pattern
+    sql: SELECT RPAD('b', 5, 'a')
+    expected:
+      rows:
+        - ['baaaa']
+  - desc: upstream example — repeated pattern truncated to the gap
+    sql: SELECT RPAD('abc', 10, 'ghd')
+    expected:
+      rows:
+        - ['abcghdghdg']
+  - desc: upstream example — return_length shorter than the value truncates
+    sql: SELECT RPAD('abc', 2, 'd')
+    expected:
+      rows:
+        - ['ab']
+  - desc: upstream example — BYTES value and pattern
+    sql: SELECT FORMAT('%T', RPAD(b'abc', 10, b'ghd'))
+    expected:
+      rows:
+        - ['b"abcghdghdg"']
+  # Same rule as the BYTES Example above, with the pattern longer than
+  # the gap it fills: the pattern is truncated, not repeated. Values
+  # from the GoogleSQL compliance fixtures (padding function tests).
+  - desc: BYTES pattern longer than the remaining gap
+    sql: SELECT FORMAT('%T', RPAD(b'abc', 5, b'defgh'))
+    expected:
+      rows:
+        - ['b"abcde"']
+  - desc: STRING pattern longer than the remaining gap
+    sql: SELECT RPAD('abc', 5, 'defgh')
+    expected:
+      rows:
+        - ['abcde']
+  - desc: empty value padded with a repeated pattern
+    sql: SELECT RPAD('', 7, 'def')
+    expected:
+      rows:
+        - ['defdefd']
+  - desc: NULL value propagates
+    sql: SELECT RPAD(CAST(NULL AS STRING), 5, '*')
+    expected:
+      rows:
+        - [null]
+  - desc: negative return_length is an error
+    sql: SELECT RPAD('abc', -1)
+    expected:
+      error:
+        contains: cannot be negative
+  - desc: negative return_length on BYTES is an error
+    sql: SELECT RPAD(b'abc', -1, b'x')
+    expected:
+      error:
+        contains: cannot be negative
+  - desc: empty pattern is an error
+    sql: SELECT RPAD('abc', 5, '')
+    expected:
+      error:
+        contains: cannot be empty
+  - desc: empty BYTES pattern is an error
+    sql: SELECT RPAD(b'abc', 5, b'')
+    expected:
+      error:
+        contains: cannot be empty
+  # Source: reference implementation string.cc:1440 (1f8aa33) — the pad
+  # arguments are verified before the output_size <= input length path,
+  # so a value that only needs truncating is rejected too.
+  - desc: empty pattern is an error when the value is truncated
+    sql: SELECT RPAD('abc', 2, '')
+    expected:
+      error:
+        contains: cannot be empty
+  - desc: empty BYTES pattern is an error when the value is unchanged
+    sql: SELECT RPAD(b'abc', 3, b'')
+    expected:
+      error:
+        contains: cannot be empty


### PR DESCRIPTION
> Written by an AI agent (Claude Code); reviewed by a human before opening.

`LPAD`/`RPAD`, `REPEAT` and `REGEXP_INSTR` panic on documented error
input — a negative length, an empty pad pattern, a negative repeat
count, an out-of-range `occurrence_position` — and `LPAD`/`RPAD` also
panic on the valid BYTES input where the pad pattern is at least as long
as the gap it fills. The panic crosses the `database/sql` boundary and
can wedge the connection instead of surfacing as an error. Six more
functions accept arguments the documentation rejects, or return the
wrong value for them.

- `lpad.go`, `rpad.go`: reject a negative `return_length` and an empty
  pattern; assign the pattern before the repeat branch so the BYTES arms
  truncate a too-long pattern instead of indexing a nil slice.
- `repeat.go`: reject a negative count before `strings.Repeat`.
- `regexp_instr.go`: reject an `occurrence_position` other than 0 or 1.
- `chr.go`, `code_points_to_string.go`: reject code points outside
  [0, 0xD7FF] and [0xE000, 0x10FFFF] instead of yielding U+FFFD.
- `regexp_extract.go`: reject patterns with more than one capturing
  group (the last group was returned), and return NULL — not `''` — for
  a group that did not participate in the match.
- `ascii.go`: read the first byte of a BYTES value directly (it was
  base64-encoded first, so `ASCII(b'\xff')` was 47) and reject STRING
  input whose first character is not ASCII.
- `edit_distance.go`, `collate.go`: reject a negative `max_distance` and
  a `language_tag` that is not a locale, `und`, `unicode` or `binary`.

Testdata: `testdata/specs/googlesql/functions/string/{lpad,rpad,repeat,regexp_instr,regexp_extract,chr,code_points_to_string,edit_distance,collate,ascii}.yaml`
now carry every upstream Example from
`docs/third_party/googlesql-docs/string_functions.md` plus the
documented error conditions; the BYTES padding and `ASCII` rows come
from the GoogleSQL compliance fixtures.

Best reviewed commit by commit: each defect is fixed in its own commit
together with the testdata that covers it, so every commit stands alone
and is green.

`make test`, `make lint` and `make validate` pass.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
