### PR TITLE
datetime: accept DATETIME(string), DATETIME(datetime), TIMESTAMP(timestamp), TIME(time)

### DIFF
--- a/internal/functions/datetime/datetime.go
+++ b/internal/functions/datetime/datetime.go
@@ -116,8 +116,20 @@ func DATETIME(args ...value.Value) (value.Value, error) {
 			return value.DatetimeValue(t.In(loc)), nil
 		}
 		return value.DatetimeValue(t), nil
+	case value.DatetimeValue:
+		if len(args) == 1 {
+			return v, nil
+		}
+	case value.StringValue:
+		if len(args) == 1 {
+			t, err := v.ToTime()
+			if err != nil {
+				return nil, fmt.Errorf("DATETIME: %w", err)
+			}
+			return value.DatetimeValue(t), nil
+		}
 	}
-	return nil, fmt.Errorf("DATETIME: first argument must be DATE or TIMESTAMP type")
+	return nil, fmt.Errorf("DATETIME: first argument must be DATE, DATETIME, TIMESTAMP or STRING type")
 }
 
 // BindDatetime short-circuits to NULL when any argument is NULL;

--- a/internal/functions/datetime/datetime_test.go
+++ b/internal/functions/datetime/datetime_test.go
@@ -83,6 +83,41 @@ func TestBindDatetimeFromTimestampZone(t *testing.T) {
 	}
 }
 
+func TestBindDatetimeFromString(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want gotime.Time
+	}{
+		{"2025-01-15T10:30:00", gotime.Date(2025, 1, 15, 10, 30, 0, 0, gotime.UTC)},
+		{"2025-01-15", gotime.Date(2025, 1, 15, 0, 0, 0, 0, gotime.UTC)},
+	} {
+		got, err := BindDatetime(value.StringValue(tc.in))
+		if err != nil {
+			t.Fatalf("DATETIME(%q): %v", tc.in, err)
+		}
+		if _, ok := got.(value.DatetimeValue); !ok {
+			t.Fatalf("DATETIME(%q): want DatetimeValue, got %T", tc.in, got)
+		}
+		if tt, _ := got.ToTime(); !tt.Equal(tc.want) {
+			t.Fatalf("DATETIME(%q): got %v, want %v", tc.in, tt, tc.want)
+		}
+	}
+	if _, err := BindDatetime(value.StringValue("not a datetime")); err == nil {
+		t.Fatalf("DATETIME(invalid string) must fail")
+	}
+}
+
+func TestBindDatetimeFromDatetime(t *testing.T) {
+	in := mkDatetime(2025, 1, 15, 10, 30, 0)
+	got, err := BindDatetime(in)
+	if err != nil {
+		t.Fatalf("BindDatetime: %v", err)
+	}
+	if got != in {
+		t.Fatalf("DATETIME(datetime) must be the identity, got %v", got)
+	}
+}
+
 func TestBindDatetimeNullPropagation(t *testing.T) {
 	got, _ := BindDatetime(nil)
 	if got != nil {

--- a/internal/functions/time/time.go
+++ b/internal/functions/time/time.go
@@ -67,6 +67,10 @@ func TIME(args ...value.Value) (value.Value, error) {
 			return nil, err
 		}
 		return value.TimeValue(t), nil
+	case value.TimeValue:
+		if len(args) == 1 {
+			return args[0], nil
+		}
 	}
 	return nil, fmt.Errorf("TIME: invalid first argument type %T", args[0])
 }

--- a/internal/functions/time/time_test.go
+++ b/internal/functions/time/time_test.go
@@ -77,6 +77,17 @@ func TestBindTimeFromDatetime(t *testing.T) {
 	}
 }
 
+func TestBindTimeFromTime(t *testing.T) {
+	in := mkTime(t, 10, 30, 0)
+	got, err := BindTime(in)
+	if err != nil {
+		t.Fatalf("BindTime: %v", err)
+	}
+	if got != value.Value(in) {
+		t.Fatalf("TIME(time) must be the identity, got %v", got)
+	}
+}
+
 // TestBindTimeNullPropagation: any NULL argument returns SQL NULL.
 func TestBindTimeNullPropagation(t *testing.T) {
 	got, err := BindTime(nil, value.IntValue(0), value.IntValue(0))

--- a/internal/functions/timestamp/timestamp.go
+++ b/internal/functions/timestamp/timestamp.go
@@ -33,6 +33,8 @@ func TIMESTAMP(v value.Value, zone string) (value.Value, error) {
 			return nil, err
 		}
 		return value.TimestampValue(modified), nil
+	case value.TimestampValue:
+		return v, nil
 	}
 	return nil, fmt.Errorf("TIMESTAMP: invalid first argument type %T", v)
 }

--- a/internal/functions/timestamp/timestamp_bind_test.go
+++ b/internal/functions/timestamp/timestamp_bind_test.go
@@ -60,6 +60,17 @@ func TestBindTimestampFromString(t *testing.T) {
 	}
 }
 
+func TestBindTimestampFromTimestamp(t *testing.T) {
+	in := mkTimestamp(2025, 1, 1, 10, 30, 0)
+	got, err := BindTimestamp(in)
+	if err != nil {
+		t.Fatalf("BindTimestamp: %v", err)
+	}
+	if got != in {
+		t.Fatalf("TIMESTAMP(timestamp) must be the identity, got %v", got)
+	}
+}
+
 func TestBindTimestampStringZone(t *testing.T) {
 	got, err := BindTimestamp(value.StringValue("2024-06-15 00:00:00"), value.StringValue("UTC"))
 	if err != nil {

--- a/testdata/specs/googlesql/functions/datetime/datetime.yaml
+++ b/testdata/specs/googlesql/functions/datetime/datetime.yaml
@@ -6,3 +6,13 @@ cases:
     expected:
       rows:
         - ["2024-03-15T12:30:45"]
+  - desc: datetime from string
+    sql: SELECT DATETIME('2025-01-15T10:30:00'), DATETIME('2025-01-15 10:30:00.123456'), DATETIME('2025-01-15')
+    expected:
+      rows:
+        - ["2025-01-15T10:30:00", "2025-01-15T10:30:00.123456", "2025-01-15T00:00:00"]
+  - desc: datetime from datetime is the identity
+    sql: SELECT DATETIME(DATETIME '2025-01-15 10:30:00')
+    expected:
+      rows:
+        - ["2025-01-15T10:30:00"]

--- a/testdata/specs/googlesql/functions/time/time.yaml
+++ b/testdata/specs/googlesql/functions/time/time.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - ["12:30:45"]
+  - desc: time from time is the identity
+    sql: SELECT CAST(TIME(TIME '12:30:45') AS STRING)
+    expected:
+      rows:
+        - ["12:30:45"]

--- a/testdata/specs/googlesql/functions/timestamp/timestamp.yaml
+++ b/testdata/specs/googlesql/functions/timestamp/timestamp.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [1710504000]
+  - desc: timestamp from timestamp is the identity
+    sql: SELECT UNIX_SECONDS(TIMESTAMP(TIMESTAMP "2024-03-15 12:00:00+00"))
+    expected:
+      rows:
+        - [1710504000]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

The analyzer resolves the single-argument conversion / identity signatures
of the date-time constructors, but the runtime implementations reject the
argument type, so these fail at execution although BigQuery accepts them:

| SQL | got | want (BigQuery) |
| -- | -- | -- |
| `DATETIME('2025-01-15T10:30:00')` | `DATETIME: first argument must be DATE or TIMESTAMP type` | `2025-01-15T10:30:00` |
| `DATETIME('2025-01-15')` | same error | `2025-01-15T00:00:00` |
| `DATETIME(DATETIME '2025-01-15 10:30:00')` | same error | identity |
| `TIMESTAMP(TIMESTAMP '2025-01-01 10:30:00+00')` | `TIMESTAMP: invalid first argument type value.TimestampValue` | identity |
| `TIME(TIME '10:30:00')` | `TIME: invalid first argument type value.TimeValue` | identity |

The string form matters in practice because test-fixture generators
commonly render datetime values as `DATETIME('<iso string>')`.

## Cause

`internal/functions/{datetime,timestamp,time}`: the type switches in
`DATETIME`, `TIMESTAMP` and `TIME` have no `StringValue` / same-type arm,
while the analyzer (its own no-match diagnostics list e.g.
`TIMESTAMP(TIMESTAMP)`) resolves those signatures.

## Fix

`DATETIME(string)` parses like `CAST(string AS DATETIME)`; the same-type
forms return the argument unchanged. If #41 lands first, `DATETIME(string)`
should route through its canonical parser — happy to rebase either way.

## Tests

Spec cases in `testdata/specs/googlesql/functions/{datetime,timestamp,time}/*.yaml`
plus unit tests per package; each fails before and passes after.
`go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass.

References: BigQuery datetime_functions#datetime, timestamp_functions#timestamp,
time_functions#time (signature lists); values confirmed against BigQuery.
