### PR TITLE
json: type JSON_QUERY / JSON_EXTRACT results like their input

### DIFF
--- a/internal/functions/json/json_bind_test.go
+++ b/internal/functions/json/json_bind_test.go
@@ -219,14 +219,13 @@ func TestBindJsonExtractArray(t *testing.T) {
 		t.Fatalf("expected 3, got %d", len(arr.Values))
 	}
 
-	// Array with null element.
 	got, err = BindJsonExtractArray(value.StringValue(`[1, null, 3]`), value.StringValue("$"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	arr = mustArray(t, got)
-	if arr.Values[1] != nil {
-		t.Fatal("expected null element")
+	if arr.Values[1] != value.Value(value.StringValue("null")) {
+		t.Fatalf("expected STRING \"null\" element, got %#v", arr.Values[1])
 	}
 
 	// Non-array path -> NULL.
@@ -338,6 +337,36 @@ func TestBindJsonQuery(t *testing.T) {
 
 	if v, _ := BindJsonQuery(nil, value.StringValue("$.a")); v != nil {
 		t.Fatal("expected null")
+	}
+}
+
+func TestJsonQueryResultTypedLikeInput(t *testing.T) {
+	t.Parallel()
+
+	str, js, path := value.StringValue(`{"a":"x","n":null,"l":[1,null]}`), value.JsonValue(`{"a":"x","n":null,"l":[1,null]}`), value.StringValue("$.a")
+	for name, fn := range map[string]func(...value.Value) (value.Value, error){"JSON_QUERY": BindJsonQuery, "JSON_EXTRACT": BindJsonExtract} {
+		if got, _ := fn(str, path); got != value.Value(value.StringValue(`"x"`)) {
+			t.Errorf("%s(string): got %#v, want STRING %q", name, got, `"x"`)
+		}
+		if got, _ := fn(js, path); got != value.Value(value.JsonValue(`"x"`)) {
+			t.Errorf("%s(json): got %#v, want JSON %q", name, got, `"x"`)
+		}
+		if got, _ := fn(str, value.StringValue("$.n")); got != nil {
+			t.Errorf("%s(string) at JSON null: got %#v, want SQL NULL", name, got)
+		}
+		if got, _ := fn(js, value.StringValue("$.n")); got != value.Value(value.JsonValue("null")) {
+			t.Errorf("%s(json) at JSON null: got %#v, want JSON null", name, got)
+		}
+	}
+	for name, fn := range map[string]func(...value.Value) (value.Value, error){"JSON_QUERY_ARRAY": BindJsonQueryArray, "JSON_EXTRACT_ARRAY": BindJsonExtractArray} {
+		got, _ := fn(str, value.StringValue("$.l"))
+		if arr := mustArray(t, got); arr.Values[0] != value.Value(value.StringValue("1")) || arr.Values[1] != value.Value(value.StringValue("null")) {
+			t.Errorf("%s(string): got %#v, want STRING elements [\"1\" \"null\"]", name, arr.Values)
+		}
+		got, _ = fn(js, value.StringValue("$.l"))
+		if arr := mustArray(t, got); arr.Values[0] != value.Value(value.JsonValue("1")) || arr.Values[1] != value.Value(value.JsonValue("null")) {
+			t.Errorf("%s(json): got %#v, want JSON elements [1 null]", name, arr.Values)
+		}
 	}
 }
 

--- a/internal/functions/json/json_extract.go
+++ b/internal/functions/json/json_extract.go
@@ -1,45 +1,26 @@
 package json
 
 import (
-	"bytes"
-	"fmt"
-
-	"github.com/goccy/go-json"
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
-func JSON_EXTRACT(v, path string) (value.Value, error) {
-	p, err := json.CreatePath(path)
+func JSON_EXTRACT(input value.Value, path string) (value.Value, error) {
+	doc, err := input.ToString()
 	if err != nil {
 		return nil, err
 	}
-	extracted, err := p.Extract([]byte(v))
-	if err != nil {
+	text, found, err := queryJSONText("JSON_EXTRACT", doc, path, true)
+	if err != nil || !found {
 		return nil, err
 	}
-	if len(extracted) == 0 {
-		return nil, nil
-	}
-	var buf bytes.Buffer
-	if err := json.Compact(&buf, extracted[0]); err != nil {
-		return nil, fmt.Errorf("failed to format json %q: %w", extracted[0], err)
-	}
-	jsonValue := buf.String()
-	if jsonValue == "null" {
-		return nil, nil
-	}
-	return value.JsonValue(jsonValue), nil
+	return scalarLikeInput(input, text), nil
 }
 
 var BindJsonExtract = helper.Scalar2(func(a, b value.Value) (value.Value, error) {
-	v, err := a.ToString()
-	if err != nil {
-		return nil, err
-	}
 	path, err := b.ToString()
 	if err != nil {
 		return nil, err
 	}
-	return JSON_EXTRACT(v, path)
+	return JSON_EXTRACT(a, path)
 })

--- a/internal/functions/json/json_extract_array.go
+++ b/internal/functions/json/json_extract_array.go
@@ -1,54 +1,38 @@
 package json
 
 import (
-	"bytes"
-
 	"github.com/goccy/go-json"
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
-func JSON_EXTRACT_ARRAY(v, path string) (value.Value, error) {
-	p, err := json.CreatePath(path)
+func JSON_EXTRACT_ARRAY(input value.Value, path string) (value.Value, error) {
+	doc, err := input.ToString()
 	if err != nil {
 		return nil, err
 	}
-	extracted, err := p.Extract([]byte(v))
-	if err != nil {
+	text, found, err := queryJSONText("JSON_EXTRACT_ARRAY", doc, path, true)
+	if err != nil || !found {
 		return nil, err
 	}
-	if len(extracted) == 0 {
+	if len(text) == 0 || text[0] != '[' {
 		return nil, nil
 	}
-	content := bytes.TrimLeft(extracted[0], " ")
-	if len(content) != 0 && content[0] != '[' {
-		// not array content
-		return nil, nil
-	}
-	var values []json.RawMessage
-	if err := json.Unmarshal(content, &values); err != nil {
+	var elems []json.RawMessage
+	if err := json.Unmarshal([]byte(text), &elems); err != nil {
 		return nil, err
 	}
 	ret := &value.ArrayValue{}
-	for _, val := range values {
-		jsonValue := string(val)
-		if jsonValue == "null" {
-			ret.Values = append(ret.Values, nil)
-		} else {
-			ret.Values = append(ret.Values, value.JsonValue(jsonValue))
-		}
+	for _, e := range elems {
+		ret.Values = append(ret.Values, elementLikeInput(input, string(e)))
 	}
 	return ret, nil
 }
 
 var BindJsonExtractArray = helper.Scalar2(func(a, b value.Value) (value.Value, error) {
-	v, err := a.ToString()
-	if err != nil {
-		return nil, err
-	}
 	path, err := b.ToString()
 	if err != nil {
 		return nil, err
 	}
-	return JSON_EXTRACT_ARRAY(v, path)
+	return JSON_EXTRACT_ARRAY(a, path)
 })

--- a/internal/functions/json/json_path_exists.go
+++ b/internal/functions/json/json_path_exists.go
@@ -24,9 +24,9 @@ func JSON_PATH_EXISTS(args ...value.Value) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	got, err := JSON_QUERY(body, path)
+	text, found, err := queryJSONText("JSON_PATH_EXISTS", body, path, false)
 	if err != nil {
 		return value.BoolValue(false), nil
 	}
-	return value.BoolValue(got != nil), nil
+	return value.BoolValue(found && text != "null"), nil
 }

--- a/internal/functions/json/json_query.go
+++ b/internal/functions/json/json_query.go
@@ -9,40 +9,63 @@ import (
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
-func JSON_QUERY(v, path string) (value.Value, error) {
+func queryJSONText(name, doc, path string, allowSingleQuotes bool) (text string, found bool, err error) {
 	p, err := json.CreatePath(path)
 	if err != nil {
-		return nil, err
+		return "", false, err
 	}
-	if p.UsedSingleQuotePathSelector() {
-		return nil, fmt.Errorf("JSON_QUERY: doesn't use single quote path selector")
+	if !allowSingleQuotes && p.UsedSingleQuotePathSelector() {
+		return "", false, fmt.Errorf("%s: doesn't use single quote path selector", name)
 	}
-	extracted, err := p.Extract([]byte(v))
+	extracted, err := p.Extract([]byte(doc))
 	if err != nil {
-		return nil, err
+		return "", false, err
 	}
 	if len(extracted) == 0 {
-		return nil, nil
+		return "", false, nil
 	}
 	var buf bytes.Buffer
 	if err := json.Compact(&buf, extracted[0]); err != nil {
-		return nil, fmt.Errorf("failed to format json %q: %w", extracted[0], err)
+		return "", false, fmt.Errorf("failed to format json %q: %w", extracted[0], err)
 	}
-	jsonValue := buf.String()
-	if jsonValue == "null" {
-		return nil, nil
-	}
-	return value.JsonValue(jsonValue), nil
+	return buf.String(), true, nil
 }
 
-var BindJsonQuery = helper.Scalar2(func(a, b value.Value) (value.Value, error) {
-	v, err := a.ToString()
+// json_functions.md#json_query "Return type": results are typed like the input;
+// a JSON null is SQL NULL only for a STRING input, and never for array elements.
+func scalarLikeInput(input value.Value, text string) value.Value {
+	if _, ok := input.(value.JsonValue); ok {
+		return value.JsonValue(text)
+	}
+	if text == "null" {
+		return nil
+	}
+	return value.StringValue(text)
+}
+
+func elementLikeInput(input value.Value, text string) value.Value {
+	if _, ok := input.(value.JsonValue); ok {
+		return value.JsonValue(text)
+	}
+	return value.StringValue(text)
+}
+
+func JSON_QUERY(input value.Value, path string) (value.Value, error) {
+	doc, err := input.ToString()
 	if err != nil {
 		return nil, err
 	}
+	text, found, err := queryJSONText("JSON_QUERY", doc, path, false)
+	if err != nil || !found {
+		return nil, err
+	}
+	return scalarLikeInput(input, text), nil
+}
+
+var BindJsonQuery = helper.Scalar2(func(a, b value.Value) (value.Value, error) {
 	path, err := b.ToString()
 	if err != nil {
 		return nil, err
 	}
-	return JSON_QUERY(v, path)
+	return JSON_QUERY(a, path)
 })

--- a/internal/functions/json/json_query_array.go
+++ b/internal/functions/json/json_query_array.go
@@ -1,58 +1,38 @@
 package json
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/goccy/go-json"
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
-func JSON_QUERY_ARRAY(v, path string) (value.Value, error) {
-	p, err := json.CreatePath(path)
+func JSON_QUERY_ARRAY(input value.Value, path string) (value.Value, error) {
+	doc, err := input.ToString()
 	if err != nil {
 		return nil, err
 	}
-	if p.UsedSingleQuotePathSelector() {
-		return nil, fmt.Errorf("JSON_QUERY_ARRAY: doesn't use single quote path selector")
-	}
-	extracted, err := p.Extract([]byte(v))
-	if err != nil {
+	text, found, err := queryJSONText("JSON_QUERY_ARRAY", doc, path, false)
+	if err != nil || !found {
 		return nil, err
 	}
-	if len(extracted) == 0 {
+	if len(text) == 0 || text[0] != '[' {
 		return nil, nil
 	}
-	content := bytes.TrimLeft(extracted[0], " ")
-	if len(content) != 0 && content[0] != '[' {
-		// not array content
-		return nil, nil
-	}
-	var values []json.RawMessage
-	if err := json.Unmarshal(content, &values); err != nil {
+	var elems []json.RawMessage
+	if err := json.Unmarshal([]byte(text), &elems); err != nil {
 		return nil, err
 	}
 	ret := &value.ArrayValue{}
-	for _, val := range values {
-		jsonValue := string(val)
-		if jsonValue == "null" {
-			ret.Values = append(ret.Values, nil)
-		} else {
-			ret.Values = append(ret.Values, value.JsonValue(jsonValue))
-		}
+	for _, e := range elems {
+		ret.Values = append(ret.Values, elementLikeInput(input, string(e)))
 	}
 	return ret, nil
 }
 
 var BindJsonQueryArray = helper.Scalar2(func(a, b value.Value) (value.Value, error) {
-	v, err := a.ToString()
-	if err != nil {
-		return nil, err
-	}
 	path, err := b.ToString()
 	if err != nil {
 		return nil, err
 	}
-	return JSON_QUERY_ARRAY(v, path)
+	return JSON_QUERY_ARRAY(a, path)
 })

--- a/query_test.go
+++ b/query_test.go
@@ -7613,7 +7613,7 @@ SELECT
   JSON_EXTRACT('{"a":null}', "$.b"),
   JSON_EXTRACT(JSON '{"a":null}', "$.a"),
   JSON_EXTRACT(JSON '{"a":null}', "$.b")`,
-			expectedRows: [][]any{{nil, nil, nil, nil}},
+			expectedRows: [][]any{{nil, nil, "null", nil}},
 		},
 		{
 			name:         "json_query",
@@ -7677,7 +7677,7 @@ SELECT
   JSON_QUERY('{"a":null}', "$.b"),
   JSON_QUERY(JSON '{"a":null}', "$.a"),
   JSON_QUERY(JSON '{"a":null}', "$.b")`,
-			expectedRows: [][]any{{nil, nil, nil, nil}},
+			expectedRows: [][]any{{nil, nil, "null", nil}},
 		},
 		{
 			name:         "json_extract_scalar with number",

--- a/testdata/specs/googlesql/functions/json/json_extract.yaml
+++ b/testdata/specs/googlesql/functions/json/json_extract.yaml
@@ -7,3 +7,9 @@ cases:
     expected:
       rows:
         - ["1"]
+  - desc: string input result is a STRING usable by string functions
+    sql: |
+      SELECT REGEXP_EXTRACT_ALL(JSON_EXTRACT('{"a": "x1y2"}', '$.a'), r'\d'), UPPER(JSON_EXTRACT('{"a": "q"}', "$.a"))
+    expected:
+      rows:
+        - [['1', '2'], '"Q"']

--- a/testdata/specs/googlesql/functions/json/json_extract_array.yaml
+++ b/testdata/specs/googlesql/functions/json/json_extract_array.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - ['[1,2,3]']
+  - desc: string input yields ARRAY<STRING> of JSON-formatted elements, nulls included
+    sql: SELECT ARRAY_TO_STRING(JSON_EXTRACT_ARRAY('[1, null, "s"]', '$'), '|')
+    expected:
+      rows:
+        - ['1|null|"s"']

--- a/testdata/specs/googlesql/functions/json/json_query.yaml
+++ b/testdata/specs/googlesql/functions/json/json_query.yaml
@@ -7,3 +7,21 @@ cases:
     expected:
       rows:
         - ["7"]
+  - desc: JSON input returns JSON
+    sql: |
+      SELECT JSON_QUERY(JSON '{"class": {"students": [{"id": 5}, {"id": 12}]}}', '$.class')
+    expected:
+      rows:
+        - ['{"students":[{"id":5},{"id":12}]}']
+  - desc: string input result is a STRING usable by string functions
+    sql: |
+      SELECT UPPER(JSON_QUERY('{"a": "x1y2"}', '$.a')), CONCAT(JSON_QUERY('{"a": {"b": 1}}', '$.a'), '!')
+    expected:
+      rows:
+        - ['"X1Y2"', '{"b":1}!']
+  - desc: JSON null is SQL NULL for a string input and JSON null for a JSON input
+    sql: |
+      SELECT JSON_QUERY('{"a": null}', '$.a') IS NULL, JSON_QUERY(JSON '{"a": null}', '$.a') IS NULL, TO_JSON_STRING(JSON_QUERY(JSON '{"a": null}', '$.a'))
+    expected:
+      rows:
+        - [true, false, 'null']

--- a/testdata/specs/googlesql/functions/json/json_query_array.yaml
+++ b/testdata/specs/googlesql/functions/json/json_query_array.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - ['[{"a":1},{"a":2}]']
+  - desc: string input yields ARRAY<STRING> of JSON-formatted elements, nulls included
+    sql: SELECT ARRAY_TO_STRING(JSON_QUERY_ARRAY('["p", null, 1]', '$'), '|')
+    expected:
+      rows:
+        - ['"p"|null|1']


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

`JSON_QUERY`, `JSON_EXTRACT` and their `_ARRAY` variants always produce a
JSON runtime value, even for the `json_string_expr` signatures whose
documented return type is a JSON-formatted `STRING` (`ARRAY<STRING>`). The
analyzer types the column `STRING`, but the value carries a JSON header, so
any string function over the result fails at run time:

| SQL | got | want (docs / BigQuery) |
| -- | -- | -- |
| `UPPER(JSON_QUERY('{"a":"x1y2"}', '$.a'))` | `UPPER: value type is must be STRING or BYTES type` | `"X1Y2"` |
| `REGEXP_EXTRACT_ALL(JSON_EXTRACT('{"a":"x1y2"}', '$.a'), r'\d')` | `REGEXP_EXTRACT_ALL: val argument must be STRING or BYTES` | `[1, 2]` |
| `JSON_QUERY(JSON '{"a":null}', '$.a') IS NULL` | `true` | `false` (JSON input keeps a JSON `null`) |
| `JSON_QUERY_ARRAY('[1,null]', '$')[OFFSET(1)] IS NULL` | `true` | `false` (element is the STRING `null`) |

## Cause

`internal/functions/json/json_{query,extract,query_array,extract_array}.go`
build `value.JsonValue` unconditionally, regardless of which signature was
resolved.

## Fix

Type the result like the input: `STRING` in → JSON-formatted `STRING` out,
`JSON` in → `JSON` out, with the documented null split
(`json_functions.md#json_query`): a JSON `null` is SQL `NULL` for a STRING
input but stays a JSON `null` for a JSON input; array elements are the
STRING `"null"` / a JSON `null`, never SQL `NULL`. The four functions now
share one extraction helper. `JSON_PATH_EXISTS` keeps its previous result.
Two `query_test.go` expectations that pinned SQL `NULL` for the JSON-input
null case are updated to the documented JSON `null`.

## Tests

Spec cases in `testdata/specs/googlesql/functions/json/json_{query,extract,query_array,extract_array}.yaml`
(including the upstream JSON-input Example) and a unit test covering the
typing matrix; each fails before and passes after. `go test ./...`,
`go run ./cmd/specctl check --check` and `make lint` pass. Values confirmed
against BigQuery.
