### PR TITLE
internal: render CAST(TIMESTAMP AS STRING) in the canonical form

### DIFF
--- a/internal/cast_test.go
+++ b/internal/cast_test.go
@@ -3,6 +3,9 @@ package internal
 import (
 	"strings"
 	"testing"
+	gotime "time"
+
+	"github.com/goccy/go-googlesql"
 
 	"github.com/goccy/googlesqlite/internal/value"
 )
@@ -88,5 +91,28 @@ func TestBindCast_HappyPath(t *testing.T) {
 	s, _ := got.ToString()
 	if !strings.Contains(s, "42") {
 		t.Fatalf("expected result containing 42, got %q", s)
+	}
+}
+
+func TestCastTimestampToStringCanonicalForm(t *testing.T) {
+	for _, tc := range []struct {
+		in   gotime.Time
+		want string
+	}{
+		{gotime.Date(2026, 8, 7, 22, 0, 0, 0, gotime.UTC), "2026-08-07 22:00:00+00"},
+		{gotime.Date(2020, 1, 1, 0, 0, 0, 500000000, gotime.UTC), "2020-01-01 00:00:00.500+00"},
+		{gotime.Date(2020, 1, 1, 0, 0, 0, 123400000, gotime.UTC), "2020-01-01 00:00:00.123400+00"},
+		{gotime.Date(2020, 1, 1, 3, 0, 0, 0, gotime.FixedZone("", 3*3600)), "2020-01-01 00:00:00+00"},
+	} {
+		if got := castTimestampToString(tc.in); got != tc.want {
+			t.Errorf("castTimestampToString(%v): got %q, want %q", tc.in, got, tc.want)
+		}
+		got, err := CastValue(m1(tf().MakeSimpleType(googlesql.TypeKindTypeString)), value.TimestampValue(tc.in))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != value.Value(value.StringValue(tc.want)) {
+			t.Errorf("CastValue(STRING, TIMESTAMP %v): got %#v, want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -490,6 +490,9 @@ func CastValue(t googlesql.Googlesql_TypeNode, v value.Value) (value.Value, erro
 		}
 		return value.FloatValue(f64), nil
 	case googlesql.TypeKindTypeString, googlesql.TypeKindTypeEnum:
+		if ts, ok := v.(value.TimestampValue); ok {
+			return value.StringValue(castTimestampToString(time.Time(ts))), nil
+		}
 		s, err := v.ToString()
 		if err != nil {
 			return nil, err
@@ -759,4 +762,16 @@ func encodeValueAgainstParamType(v any, t googlesql.Googlesql_TypeNode) (any, er
 		}
 	}
 	return encodeGoValue(t, v)
+}
+
+func castTimestampToString(t time.Time) string {
+	t = t.UTC()
+	switch us := t.Nanosecond() / 1000; {
+	case us == 0:
+		return t.Format("2006-01-02 15:04:05+00")
+	case us%1000 == 0:
+		return t.Format("2006-01-02 15:04:05.000+00")
+	default:
+		return t.Format("2006-01-02 15:04:05.000000+00")
+	}
 }

--- a/testdata/specs/googlesql/syntax/query/cast.yaml
+++ b/testdata/specs/googlesql/syntax/query/cast.yaml
@@ -21,3 +21,13 @@ cases:
     expected:
       rows:
         - ['true']
+  - desc: cast timestamp column to string uses the canonical space/+00 form
+    sql: |-
+      SELECT CAST(ts AS STRING) AS r
+      FROM UNNEST([TIMESTAMP '2026-08-07 22:00:00+00', TIMESTAMP '2020-01-01 00:00:00.5+00', TIMESTAMP '2020-01-01 00:00:00.1234+00']) AS ts
+    expected:
+      unordered: true
+      rows:
+        - ['2026-08-07 22:00:00+00']
+        - ['2020-01-01 00:00:00.500+00']
+        - ['2020-01-01 00:00:00.123400+00']


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

A runtime `CAST` of a `TIMESTAMP` to `STRING` renders RFC 3339, unlike every
other timestamp-to-text path in the driver and unlike BigQuery:

```sql
SELECT CAST(ts AS STRING) FROM (SELECT TIMESTAMP '2026-08-07 22:00:00+00' AS ts)
--   got:  2026-08-07T22:00:00Z
--   want: 2026-08-07 22:00:00+00   (BigQuery; also STRING(ts), FORMAT('%t', ts),
--                                  and the driver's own TIMESTAMP column rendering)
```

so string comparisons and `CONCAT`-built keys over cast timestamps diverge
from BigQuery. Fractional seconds: BigQuery prints 0, 3 or 6 digits
(`.500`, `.123400`).

## Cause

`CastValue` (`internal/encoder.go`) sends the `STRING` target through
`TimestampValue.ToString()`, which formats with `time.RFC3339Nano`.

## Fix

Format a `TIMESTAMP` source for the `STRING` cast target as
`YYYY-MM-DD HH:MM:SS[.fff|.ffffff]+00` in UTC. Scoped to the cast target
only; `ToString` (used by the row hand-off) is untouched, and literal casts
folded by the analyzer are not affected. Related but intentionally out of
scope: the `DATETIME`-to-`STRING` `T` separator and the analyzer's default
time zone for folded literals.

## Tests

`testdata/specs/googlesql/syntax/query/cast.yaml` (column cast, three
fraction widths) and a unit test in `internal/cast_test.go`; both fail
before and pass after. `go test ./...`, `go run ./cmd/specctl check --check`
and `make lint` pass. Values confirmed against BigQuery.
