### PR TITLE
internal: blank SQL comments before the pre-parse text rewrites

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -1089,6 +1089,54 @@ func scanStringLiteral(s string, start int) int {
 	return len(s)
 }
 
+// blankComments overwrites comments with spaces, keeping newlines, so
+// positions reported by the parser still match the original query.
+func blankComments(query string) string {
+	if !strings.Contains(query, "--") && !strings.Contains(query, "#") && !strings.Contains(query, "/*") {
+		return query
+	}
+	b := []byte(query)
+	blank := func(from, to int) {
+		for k := from; k < to; k++ {
+			if b[k] != '\n' {
+				b[k] = ' '
+			}
+		}
+	}
+	i := 0
+	for i < len(query) {
+		c := query[i]
+		switch {
+		case c == '\'' || c == '"':
+			i = scanStringLiteral(query, i)
+		case c == '`':
+			end := i + 1
+			for end < len(query) && query[end] != '`' {
+				end++
+			}
+			i = end + 1
+		case c == '#' || (c == '-' && i+1 < len(query) && query[i+1] == '-'):
+			end := i
+			for end < len(query) && query[end] != '\n' {
+				end++
+			}
+			blank(i, end)
+			i = end
+		case c == '/' && i+1 < len(query) && query[i+1] == '*':
+			end := strings.Index(query[i+2:], "*/")
+			if end < 0 {
+				return string(b)
+			}
+			end += i + 4
+			blank(i, end)
+			i = end
+		default:
+			i++
+		}
+	}
+	return string(b)
+}
+
 // parsedScript bundles parsed statements with the handles they point
 // into. The ParserOutput handles own the AST subtrees referenced by
 // stmts; keeping them live here lets callers iterate AST nodes without
@@ -1518,6 +1566,7 @@ func (a *Analyzer) Analyze(ctx context.Context, conn *Conn, query string, args [
 	// arg slice, applyScriptVariables needs ctx/conn) stay as explicit
 	// calls in their exact positions relative to the uniform pipeline
 	// steps.
+	query = blankComments(query)
 	query, args = applyMixedParameterRewrite(query, args)
 	query = applySQLRewritePipeline(query, sqlRewritePipelinePreScriptVars)
 	query = applyScriptVariables(ctx, query, conn)

--- a/internal/analyzer_comments_test.go
+++ b/internal/analyzer_comments_test.go
@@ -1,0 +1,23 @@
+package internal
+
+import "testing"
+
+func TestBlankCommentsPreservesOffsetsAndLiterals(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"SELECT 1 -- it's\nFROM t", "SELECT 1        \nFROM t"},
+		{"# PARTITION BY x\nSELECT 1", "                \nSELECT 1"},
+		{"SELECT /* it's\nmulti */ 1", "SELECT        \n         1"},
+		{"SELECT '-- a /* b */ #c' AS s", "SELECT '-- a /* b */ #c' AS s"},
+		{`SELECT "it's" /* ' */, r'\d--', b"#" AS x`, `SELECT "it's"        , r'\d--', b"#" AS x`},
+		{"SELECT `a--b` /*x*/ FROM `c#d`", "SELECT `a--b`       FROM `c#d`"},
+		{"SELECT 1 /* unterminated", "SELECT 1 /* unterminated"},
+	} {
+		got := blankComments(tc.in)
+		if got != tc.want {
+			t.Errorf("blankComments(%q):\n got  %q\n want %q", tc.in, got, tc.want)
+		}
+		if len(got) != len(tc.in) {
+			t.Errorf("blankComments(%q) changed the length: %d -> %d", tc.in, len(tc.in), len(got))
+		}
+	}
+}

--- a/regression_test.go
+++ b/regression_test.go
@@ -34,6 +34,41 @@ func TestRegression_DefaultTimezoneIsUTC(t *testing.T) {
 	}
 }
 
+func TestRegression_CommentsDoNotAffectRewrites(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("googlesqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name, sql string
+		want      int64
+	}{
+		{"block comment with PARTITION BY", "SELECT 1 /* partition by day */ AS a", 1},
+		{"block comment with PARTITION BY before CTE body", "WITH t /* no PARTITION BY here */ AS (SELECT 1 AS x) SELECT x FROM t WHERE x >= 1", 1},
+		{"apostrophe in block comment before naive TIMESTAMP literal", "SELECT /* it's */ EXTRACT(HOUR FROM ts) FROM (SELECT TIMESTAMP '2024-01-01 12:00:00' AS ts)", 12},
+		{"apostrophe in dash comment before naive TIMESTAMP literal", "-- it's\nSELECT EXTRACT(HOUR FROM TIMESTAMP '2024-01-01 12:00:00')", 12},
+	} {
+		var got int64
+		if err := db.QueryRowContext(ctx, tc.sql).Scan(&got); err != nil {
+			t.Errorf("%s: %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %d, want %d", tc.name, got, tc.want)
+		}
+	}
+	var s string
+	if err := db.QueryRowContext(ctx, `SELECT '-- a /* b */ #c' /* ' */`).Scan(&s); err != nil {
+		t.Fatal(err)
+	}
+	if s != "-- a /* b */ #c" {
+		t.Errorf("comment markers inside a string literal were altered: %q", s)
+	}
+}
+
 // TestRegression_IntegerTypeAlias asserts that INTEGER and INT are accepted
 // as aliases for INT64 in DDL.
 //


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

The rewrites that run on the raw query text before parsing
(`applyMixedParameterRewrite`, `stripPartitionByClause` /
`applyIngestionPartitionRewrite`, `applyNaiveTimestampUTC`, gap-fill, …)
skip string literals but have no notion of comments, so comment text is
scanned as SQL:

| SQL | got | want |
| -- | -- | -- |
| `SELECT 1 /* partition by day */ AS a` | `Syntax error: Unclosed comment` | `1` |
| `WITH t /* no PARTITION BY here */ AS (SELECT 1 x) SELECT x FROM t WHERE x >= 1` | `Unclosed comment` (in a long query: `Expected "(" or keyword AS but got ">="` far downstream) | `1` |
| `SELECT /* it's */ ts FROM (SELECT TIMESTAMP '2025-01-01 10:00:00' ts)` | **`2025-01-01 18:00:00+00`**, silently | `2025-01-01 10:00:00+00` |
| `-- it's` ⏎ `SELECT EXTRACT(HOUR FROM TIMESTAMP '2024-01-01 12:00:00')` | `20` | `12` |

## Cause

`stripPartitionByClause` matches `PARTITION BY` inside a comment at paren
depth 0 and deletes through the next top-level `AS`, taking the `*/` with
it. An apostrophe inside a comment opens a phantom string literal for
`scanStringLiteral`, so `applyNaiveTimestampUTC` never appends `+00:00` to
the naive literal that follows and the analyzer parses it in its
`America/Los_Angeles` default — a wrong result with no error.

## Fix

`blankComments` replaces every `--`, `#` and `/* */` comment with spaces,
keeping newlines, once in `Analyzer.Analyze` ahead of all rewrites. Byte
offsets and `[at line:col]` positions are unchanged; string literals
(raw / bytes-prefixed / triple-quoted) and backtick identifiers pass
through; an unterminated block comment is left for the parser to report.
The parser treats comments as whitespace, so nothing downstream changes.

Alternative considered: teaching each scanner loop (about fifteen, across
five files) to skip comments — a larger diff, and the next scanner added
would have to remember to do the same.

## Tests

`internal/analyzer_comments_test.go` (offset / literal preservation) and
`TestRegression_CommentsDoNotAffectRewrites` in `regression_test.go` (the
four cases above plus comment markers inside a string literal); each fails
before and passes after. `go test ./...`, `go run ./cmd/specctl check --check`
and `make lint` pass.

References: lexical.md#comments (comments are whitespace); BigQuery's
default time zone is UTC.
