### PR TITLE
value: render FLOAT64 as text the way BigQuery does (CAST, CONCAT, FORMAT %t/%T, TO_JSON_STRING)

### DIFF
--- a/internal/value/value_float.go
+++ b/internal/value/value_float.go
@@ -2,7 +2,10 @@ package value
 
 import (
 	"fmt"
+	"math"
 	"math/big"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -88,11 +91,27 @@ func (fv FloatValue) ToInt64() (int64, error) {
 }
 
 func (fv FloatValue) ToString() (string, error) {
-	return fmt.Sprint(fv), nil
+	return formatFloat(float64(fv)), nil
 }
 
 func (fv FloatValue) ToBytes() ([]byte, error) {
-	return []byte(fmt.Sprint(fv)), nil
+	return []byte(formatFloat(float64(fv))), nil
+}
+
+func formatFloat(f float64) string {
+	switch {
+	case math.IsNaN(f):
+		return "nan"
+	case math.IsInf(f, 1):
+		return "inf"
+	case math.IsInf(f, -1):
+		return "-inf"
+	}
+	s := strconv.FormatFloat(f, 'g', 15, 64)
+	if v, err := strconv.ParseFloat(s, 64); err != nil || v != f {
+		s = strconv.FormatFloat(f, 'g', 17, 64)
+	}
+	return s
 }
 
 func (fv FloatValue) ToFloat64() (float64, error) {
@@ -118,7 +137,16 @@ func (fv FloatValue) ToStruct() (*StructValue, error) {
 }
 
 func (fv FloatValue) ToJSON() (string, error) {
-	return fmt.Sprint(fv), nil
+	switch f := float64(fv); {
+	case math.IsNaN(f):
+		return `"NaN"`, nil
+	case math.IsInf(f, 1):
+		return `"Infinity"`, nil
+	case math.IsInf(f, -1):
+		return `"-Infinity"`, nil
+	default:
+		return formatFloat(f), nil
+	}
 }
 
 func (fv FloatValue) ToTime() (time.Time, error) {
@@ -132,7 +160,18 @@ func (fv FloatValue) ToRat() (*big.Rat, error) {
 }
 
 func (fv FloatValue) Format(verb rune) string {
-	return fmt.Sprint(fv)
+	f := float64(fv)
+	s := formatFloat(f)
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		if verb == 'T' {
+			return fmt.Sprintf("CAST(%q AS FLOAT64)", s)
+		}
+		return s
+	}
+	if !strings.ContainsAny(s, ".e") {
+		s += ".0"
+	}
+	return s
 }
 
 func (fv FloatValue) Interface() any {

--- a/internal/value/value_float_test.go
+++ b/internal/value/value_float_test.go
@@ -176,3 +176,38 @@ func TestFloatValue(t *testing.T) {
 		}
 	})
 }
+
+func TestFloatTextForms(t *testing.T) {
+	for _, tc := range []struct {
+		in                 float64
+		str, fmtt, T, json string
+	}{
+		{3, "3", "3.0", "3.0", "3"},
+		{math.Copysign(0, -1), "-0", "-0.0", "-0.0", "-0"},
+		{123456789, "123456789", "123456789.0", "123456789.0", "123456789"},
+		{1234567.5, "1234567.5", "1234567.5", "1234567.5", "1234567.5"},
+		{1e15, "1e+15", "1e+15", "1e+15", "1e+15"},
+		{1e14 + 0.5, "100000000000000.5", "100000000000000.5", "100000000000000.5", "100000000000000.5"},
+		{0.00001, "1e-05", "1e-05", "1e-05", "1e-05"},
+		{0.0001, "0.0001", "0.0001", "0.0001", "0.0001"},
+		{math.Nextafter(0.3, 1), "0.30000000000000004", "0.30000000000000004", "0.30000000000000004", "0.30000000000000004"},
+		{123456789012345678, "1.2345678901234568e+17", "1.2345678901234568e+17", "1.2345678901234568e+17", "1.2345678901234568e+17"},
+		{math.NaN(), "nan", "nan", `CAST("nan" AS FLOAT64)`, `"NaN"`},
+		{math.Inf(1), "inf", "inf", `CAST("inf" AS FLOAT64)`, `"Infinity"`},
+		{math.Inf(-1), "-inf", "-inf", `CAST("-inf" AS FLOAT64)`, `"-Infinity"`},
+	} {
+		v := value.FloatValue(tc.in)
+		if s, _ := v.ToString(); s != tc.str {
+			t.Errorf("FloatValue(%v).ToString() = %q, want %q", tc.in, s, tc.str)
+		}
+		if s := v.Format('t'); s != tc.fmtt {
+			t.Errorf("FloatValue(%v).Format('t') = %q, want %q", tc.in, s, tc.fmtt)
+		}
+		if s := v.Format('T'); s != tc.T {
+			t.Errorf("FloatValue(%v).Format('T') = %q, want %q", tc.in, s, tc.T)
+		}
+		if s, _ := v.ToJSON(); s != tc.json {
+			t.Errorf("FloatValue(%v).ToJSON() = %q, want %q", tc.in, s, tc.json)
+		}
+	}
+}

--- a/testdata/specs/googlesql/functions/json/to_json_string.yaml
+++ b/testdata/specs/googlesql/functions/json/to_json_string.yaml
@@ -44,3 +44,8 @@ cases:
     expected:
       rows:
         - ['[]']
+  - desc: FLOAT64 values use the shortest round-trip form
+    sql: SELECT TO_JSON_STRING(x * 41152263), TO_JSON_STRING(x / 30), TO_JSON_STRING(x * 1e21) FROM (SELECT 3.0 AS x)
+    expected:
+      rows:
+        - ["123456789", "0.1", "3e+21"]

--- a/testdata/specs/googlesql/functions/string/format.yaml
+++ b/testdata/specs/googlesql/functions/string/format.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - ['00042']
+  - desc: '%t and %T print FLOAT64 with a fractional part'
+    sql: SELECT FORMAT('%t %T %t %t', x, x, x * 1e15, x / 3e5) FROM (SELECT 3.0 AS x)
+    expected:
+      rows:
+        - ["3.0 3.0 3e+15 1e-05"]

--- a/testdata/specs/googlesql/syntax/query/cast.yaml
+++ b/testdata/specs/googlesql/syntax/query/cast.yaml
@@ -21,3 +21,15 @@ cases:
     expected:
       rows:
         - ['true']
+  - desc: cast float64 column to string uses the shortest round-trip form
+    sql: |-
+      SELECT CAST(x AS STRING) AS r
+      FROM UNNEST([123456789.0, 1234567.5, 1e15, 0.00001, 0.1 + 0.2]) AS x WITH OFFSET o
+      ORDER BY o
+    expected:
+      rows:
+        - ['123456789']
+        - ['1234567.5']
+        - ['1e+15']
+        - ['1e-05']
+        - ['0.30000000000000004']


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

A runtime `FLOAT64` is turned into text with Go's shortest `%g` form,
which differs from BigQuery wherever a non-literal double is cast,
concatenated or formatted (literal casts look right only because the
analyzer folds them):

| SQL (x = the value) | got | want (BigQuery) |
| -- | -- | -- |
| `CAST(x AS STRING)`, x = 123456789.0 | `1.23456789e+08` | `123456789` |
| `CAST(x AS STRING)`, x = 1e15 | `1e+15` | `1e+15` |
| `CAST(x AS STRING)`, x = 0.1 + 0.2 | `0.30000000000000004` | `0.30000000000000004` |
| `FORMAT('%t', x)`, x = 3.0 | `3` | `3.0` |
| `FORMAT('%T', x)`, x = 123456789.0 | `1.23456789e+08` | `123456789.0` |
| `FORMAT('%T', x)`, x = +inf | `+Inf` | `CAST("inf" AS FLOAT64)` |
| `TO_JSON_STRING(x)`, x = 123456789.0 / +inf | `1.23456789e+08` / `+Inf` (not JSON) | `123456789` / `"Infinity"` |

## Fix

`FloatValue.ToString` uses the shortest of `%.15g` / `%.17g` that
round-trips (the rule BigQuery's output follows), with `nan`, `inf`,
`-inf` in lower case; `Format('t'|'T')` builds on it, keeps a `.0` on
integral values and spells non-finite values as `CAST("nan" AS FLOAT64)`
under `%T`; `ToJSON` uses the same digits with the JSON strings `"NaN"` /
`"Infinity"` / `"-Infinity"`. Verified against BigQuery for -0.0, 1e14+0.5, 1e16, 1e21,
1e-05, 0.0001, 2.5e-07, 1.2345678901234568e+17, nan/±inf.

Not covered here: floats nested inside ARRAY/STRUCT values lose their type
when integral (`FORMAT('%t', [1.0, 2.5])` gives `[1, 2.5]`); that is the
array codec, not the formatter.

## Tests

`internal/value/value_float_test.go` (table over ToString / %t / %T),
`testdata/specs/googlesql/syntax/query/cast.yaml`,
`testdata/specs/googlesql/functions/string/format.yaml`,
`testdata/specs/googlesql/functions/json/to_json_string.yaml`. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
