### PR TITLE
string: apply FORMAT's NULL-argument rules

### DIFF
--- a/internal/functions/string/bind_test.go
+++ b/internal/functions/string/bind_test.go
@@ -873,6 +873,25 @@ func TestCollate(t *testing.T) {
 
 // ----- FORMAT --------------------------------------------------
 
+func TestFormatNullArguments(t *testing.T) {
+	t.Parallel()
+
+	got, err := strfn.BindFormat(value.StringValue("00-%t-00 %T"), nil, nil)
+	if err != nil || !equalString(got, "00-NULL-00 NULL") {
+		t.Errorf("FORMAT %%t/%%T with NULL: got %v, %v", got, err)
+	}
+	for _, args := range [][]value.Value{
+		{nil, value.IntValue(1)},
+		{value.StringValue("%d"), nil},
+		{value.StringValue("%s %t"), nil, value.IntValue(1)},
+		{value.StringValue("%*d"), nil, value.IntValue(5)},
+	} {
+		if got, err := strfn.BindFormat(args...); err != nil || got != nil {
+			t.Errorf("FORMAT%v: got %v, %v; want NULL", args, got, err)
+		}
+	}
+}
+
 func TestFormat(t *testing.T) {
 	t.Parallel()
 

--- a/internal/functions/string/format.go
+++ b/internal/functions/string/format.go
@@ -8,16 +8,19 @@ import (
 )
 
 func FORMAT(format string, args ...value.Value) (value.Value, error) {
-	result, err := parseFormat(format, args...)
-	if err != nil {
+	result, isNull, err := parseFormat(format, args...)
+	if err != nil || isNull {
 		return nil, err
 	}
 	return value.StringValue(result), nil
 }
 
-var BindFormat = helper.ScalarN(func(args ...value.Value) (value.Value, error) {
+var BindFormat = helper.ScalarNKeepNull(func(args ...value.Value) (value.Value, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("FORMAT: invalid number of arguments: got %d, want at least 1", len(args))
+	}
+	if args[0] == nil {
+		return nil, nil
 	}
 	format, err := args[0].ToString()
 	if err != nil {

--- a/internal/functions/string/function_format.go
+++ b/internal/functions/string/function_format.go
@@ -438,29 +438,29 @@ func (p *FormatPrecision) format(args []value.Value) (int, []value.Value, error)
 	return p.num, args, nil
 }
 
-func parseFormat(format string, args ...value.Value) (string, error) {
+func parseFormat(format string, args ...value.Value) (result string, isNull bool, err error) {
 	ctx := &FormatContext{src: []rune(format)}
 	formatArgs := args
-	result := []rune{}
+	out := []rune{}
 	for ctx.idx < len(ctx.src) {
 		c := ctx.current()
 		if c != '%' {
-			result = append(result, c)
+			out = append(out, c)
 			ctx.progress(1)
 			continue
 		}
 		ctx.progress(1)
 		if len(ctx.src) <= ctx.idx {
-			return "", fmt.Errorf("invalid format")
+			return "", false, fmt.Errorf("invalid format")
 		}
 		flag := parseFormatFlag(ctx)
 		width, err := parseFormatWidth(ctx)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		precision, err := parseFormatPrecision(ctx)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		specifier := ctx.current()
 		param := &FormatParam{
@@ -471,29 +471,39 @@ func parseFormat(format string, args ...value.Value) (string, error) {
 		}
 		info, exists := formatSpecifierTable[param.specifier]
 		if !exists {
-			return "", fmt.Errorf("unexpected format type %%%c", specifier)
+			return "", false, fmt.Errorf("unexpected format type %%%c", specifier)
 		}
 		num := param.requiredArgNum()
 		if len(formatArgs) < num {
-			return "", fmt.Errorf("not enough arguments for format")
+			return "", false, fmt.Errorf("not enough arguments for format")
 		}
 		args := formatArgs[:num]
-		if err := param.validateArgs(info, args); err != nil {
-			return "", fmt.Errorf("invalid argument type: %w", err)
-		}
-		text, err := info.parse(param, args)
-		if err != nil {
-			return "", err
+		var text []rune
+		switch nullArg(args) {
+		case -1:
+			if err := param.validateArgs(info, args); err != nil {
+				return "", false, fmt.Errorf("invalid argument type: %w", err)
+			}
+			if text, err = info.parse(param, args); err != nil {
+				return "", false, err
+			}
+		case num - 1:
+			if specifier != 't' && specifier != 'T' {
+				return "", true, nil
+			}
+			text = []rune("NULL")
+		default:
+			return "", true, nil
 		}
 		if len(formatArgs) > num {
 			formatArgs = formatArgs[num:]
 		} else if num != 0 {
 			formatArgs = nil
 		}
-		result = append(result, text...)
+		out = append(out, text...)
 		ctx.progress(1)
 	}
-	return string(result), nil
+	return string(out), false, nil
 }
 
 func parseFormatFlag(ctx *FormatContext) FormatFlag {
@@ -581,4 +591,13 @@ func parseFormatPrecision(ctx *FormatContext) (*FormatPrecision, error) {
 		return &FormatPrecision{num: num}, nil
 	}
 	return nil, nil
+}
+
+func nullArg(args []value.Value) int {
+	for i, a := range args {
+		if a == nil {
+			return i
+		}
+	}
+	return -1
 }

--- a/query_test.go
+++ b/query_test.go
@@ -6201,8 +6201,8 @@ WITH examples AS (
 				{"abc", int64(5), `"abc  "`},
 				{"abc", int64(2), `"ab"`},
 				{"例子", int64(4), `"例子  "`},
-				{nil, int64(2), nil},
-				{"abc", nil, nil},
+				{nil, int64(2), "NULL"},
+				{"abc", nil, "NULL"},
 			},
 		},
 		{
@@ -6215,7 +6215,7 @@ WITH examples AS (
 			expectedRows: [][]any{
 				{"abc", int64(8), "def", `"abcdefde"`},
 				{"abc", int64(5), "-", `"abc--"`},
-				{"abc", int64(5), nil, nil},
+				{"abc", int64(5), nil, "NULL"},
 				{"例子", int64(5), "中文", `"例子中文中"`},
 			},
 		},
@@ -8122,7 +8122,7 @@ FROM (
 				{`b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"`},
 				{`b"0123456789@ABCDE"`},
 				{`b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xc0\x00\x02\x80"`},
-				{nil},
+				{"NULL"},
 			},
 		},
 		{
@@ -8258,9 +8258,9 @@ FROM (
 				{`b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"`},
 				{`b"0123456789@ABCDE"`},
 				{`b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xc0\x00\x02\x80"`},
-				{nil},
-				{nil},
-				{nil},
+				{"NULL"},
+				{"NULL"},
+				{"NULL"},
 			},
 		},
 

--- a/testdata/specs/googlesql/functions/string/format.yaml
+++ b/testdata/specs/googlesql/functions/string/format.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - ['00042']
+  - desc: a NULL argument makes the result NULL except under %t and %T
+    sql: SELECT FORMAT('00-%t-00 %T', NULL, CAST(NULL AS INT64)), FORMAT('%d', CAST(NULL AS INT64)), FORMAT('%s %t', CAST(NULL AS STRING), 1), FORMAT(CAST(NULL AS STRING), 1)
+    expected:
+      rows:
+        - ["00-NULL-00 NULL", null, null, null]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

`FORMAT` returns NULL whenever any argument is NULL. Per
string_functions.md § "NULL argument handling", that is right for every
specifier except `%t` and `%T`, which render a NULL value as the text
`NULL`:

| SQL | got | want (docs / BigQuery) |
| -- | -- | -- |
| `FORMAT('00-%t-00', NULL)` | NULL | `00-NULL-00` |
| `FORMAT('%T', CAST(NULL AS INT64))` | NULL | `NULL` (the string) |
| `FORMAT('%d', CAST(NULL AS INT64))` | NULL | NULL |
| `FORMAT('%s %t', CAST(NULL AS STRING), 1)` | NULL | NULL |
| `FORMAT(CAST(NULL AS STRING), 1)` | NULL | NULL |

## Fix

`BindFormat` no longer short-circuits on NULL; `parseFormat` reports a
NULL result when a NULL argument sits under any specifier other than
`%t`/`%T` (or feeds a `*` width / precision), and renders `NULL` under
`%t`/`%T`. Four `query_test.go` cases that used `FORMAT('%T', …)` as a
rendering wrapper pinned SQL NULL for a NULL argument; they are updated to
the documented text (the upstream examples for those functions print
`NULL` in that position too).

## Tests

`internal/functions/string/bind_test.go` and
`testdata/specs/googlesql/functions/string/format.yaml`. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
