### PR TITLE
internal: reject blank strings and ignore surrounding spaces in a runtime string to INT64 / FLOAT64 cast

### DIFF
--- a/internal/cast_test.go
+++ b/internal/cast_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-googlesql"
+
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
@@ -88,5 +90,21 @@ func TestBindCast_HappyPath(t *testing.T) {
 	s, _ := got.ToString()
 	if !strings.Contains(s, "42") {
 		t.Fatalf("expected result containing 42, got %q", s)
+	}
+}
+
+func TestCastStringToNumberRejectsBlankAndTrims(t *testing.T) {
+	i64 := m1(tf().MakeSimpleType(googlesql.TypeKindTypeInt64))
+	f64 := m1(tf().MakeSimpleType(googlesql.TypeKindTypeDouble))
+	for _, in := range []string{"", "   "} {
+		if _, err := CastValue(i64, value.StringValue(in)); err == nil {
+			t.Errorf("CastValue(INT64, %q) must fail", in)
+		}
+		if _, err := CastValue(f64, value.StringValue(in)); err == nil {
+			t.Errorf("CastValue(FLOAT64, %q) must fail", in)
+		}
+	}
+	if got, err := CastValue(i64, value.StringValue(" 12 ")); err != nil || got != value.Value(value.IntValue(12)) {
+		t.Errorf("CastValue(INT64, \" 12 \") = %v, %v; want 12", got, err)
 	}
 }

--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -472,6 +472,12 @@ func CastValue(t googlesql.Googlesql_TypeNode, v value.Value) (value.Value, erro
 	// Googlesql_TypeNode carries Kind directly, no upcast needed.
 	switch m1(t.Kind()) {
 	case googlesql.TypeKindTypeInt32, googlesql.TypeKindTypeInt64, googlesql.TypeKindTypeUint32, googlesql.TypeKindTypeUint64:
+		if s, ok := v.(value.StringValue); ok {
+			v = value.StringValue(strings.TrimSpace(string(s)))
+			if v == value.StringValue("") {
+				return nil, fmt.Errorf("invalid INT64 value: %q", string(s))
+			}
+		}
 		i64, err := v.ToInt64()
 		if err != nil {
 			return nil, err
@@ -484,6 +490,12 @@ func CastValue(t googlesql.Googlesql_TypeNode, v value.Value) (value.Value, erro
 		}
 		return value.BoolValue(b), nil
 	case googlesql.TypeKindTypeFloat, googlesql.TypeKindTypeDouble:
+		if s, ok := v.(value.StringValue); ok {
+			v = value.StringValue(strings.TrimSpace(string(s)))
+			if v == value.StringValue("") {
+				return nil, fmt.Errorf("invalid FLOAT64 value: %q", string(s))
+			}
+		}
 		f64, err := v.ToFloat64()
 		if err != nil {
 			return nil, err

--- a/testdata/specs/googlesql/functions/conversion/safe_cast.yaml
+++ b/testdata/specs/googlesql/functions/conversion/safe_cast.yaml
@@ -11,3 +11,8 @@ cases:
     expected:
       rows:
         - [null]
+  - desc: an empty or blank string is not a number, surrounding spaces are ignored
+    sql: SELECT SAFE_CAST(e AS INT64), SAFE_CAST(e AS FLOAT64), SAFE_CAST(b AS INT64), SAFE_CAST(p AS INT64), SAFE_CAST(p AS FLOAT64) FROM (SELECT '' AS e, '   ' AS b, ' 12 ' AS p)
+    expected:
+      rows:
+        - [null, null, null, 12, 12.0]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

A runtime cast of a string to a number treats the empty string as zero and
rejects surrounding spaces, unlike BigQuery (literal casts are folded by
the analyzer and already right):

| SQL (s = the value) | got | want (BigQuery) |
| -- | -- | -- |
| `SAFE_CAST(s AS INT64)`, s = '' | `0` | NULL |
| `SAFE_CAST(s AS FLOAT64)`, s = '' | `0.0` | NULL |
| `SAFE_CAST(s AS INT64)`, s = ' 12 ' | NULL | `12` |
| `CAST(s AS INT64)`, s = '' | `0` | error |

## Cause / fix

`StringValue.ToInt64` / `ToFloat64` map `""` to zero (relied on
elsewhere), and `CastValue` used them directly. For INT64 / FLOAT64 cast
targets, trim the string first and treat an empty result as an invalid
number.

## Tests

`testdata/specs/googlesql/functions/conversion/safe_cast.yaml` and
`internal/cast_test.go`. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
