### PR TITLE
internal: parse CAST('<naive string>' AS TIMESTAMP) in UTC, like naive TIMESTAMP literals

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -958,6 +958,18 @@ func applyNaiveTimestampUTC(query string) string {
 			word := query[i:j]
 			b.WriteString(word)
 			i = j
+			if strings.EqualFold(word, "CAST") || strings.EqualFold(word, "SAFE_CAST") {
+				if lit, end, ok := naiveTimestampCastLiteral(query, i); ok {
+					b.WriteString(query[i:lit])
+					content := strings.TrimSpace(query[lit+1 : end-1])
+					b.WriteByte(query[lit])
+					b.WriteString(content)
+					b.WriteString(utcSuffix(content))
+					b.WriteByte(query[lit])
+					i = end
+				}
+				continue
+			}
 			if strings.EqualFold(word, "TIMESTAMP") {
 				// Skip whitespace, then if the next token is a string
 				// literal without a TZ marker, rewrite it to UTC.
@@ -975,7 +987,7 @@ func applyNaiveTimestampUTC(query string) string {
 						if !timestampHasTZ(content) {
 							b.WriteByte(quote)
 							b.WriteString(content)
-							b.WriteString("+00:00")
+							b.WriteString(utcSuffix(content))
 							b.WriteByte(quote)
 						} else {
 							b.WriteString(query[k:end])
@@ -992,6 +1004,49 @@ func applyNaiveTimestampUTC(query string) string {
 	return b.String()
 }
 
+// naiveTimestampCastLiteral matches `( '<naive>' AS TIMESTAMP )` at query[i:] and
+// returns the span of the string literal.
+func naiveTimestampCastLiteral(query string, i int) (lit, end int, ok bool) {
+	skip := func(k int) int {
+		for k < len(query) && (query[k] == ' ' || query[k] == '\t' || query[k] == '\n' || query[k] == '\r') {
+			k++
+		}
+		return k
+	}
+	k := skip(i)
+	if k >= len(query) || query[k] != '(' {
+		return 0, 0, false
+	}
+	lit = skip(k + 1)
+	if lit >= len(query) || (query[lit] != '\'' && query[lit] != '"') {
+		return 0, 0, false
+	}
+	end = scanStringLiteral(query, lit)
+	if end <= lit+1 || end > len(query) || query[end-1] != query[lit] || timestampHasTZ(strings.TrimSpace(query[lit+1:end-1])) {
+		return 0, 0, false
+	}
+	k = skip(end)
+	if k+2 > len(query) || !strings.EqualFold(query[k:k+2], "AS") {
+		return 0, 0, false
+	}
+	k = skip(k + 2)
+	const target = "TIMESTAMP"
+	if k+len(target) > len(query) || !strings.EqualFold(query[k:k+len(target)], target) {
+		return 0, 0, false
+	}
+	if k = skip(k + len(target)); k >= len(query) || query[k] != ')' {
+		return 0, 0, false
+	}
+	return lit, end, true
+}
+
+func utcSuffix(content string) string {
+	if dateOnly.MatchString(content) {
+		return " 00:00:00+00:00"
+	}
+	return "+00:00"
+}
+
 // timestampHasTZ reports whether a TIMESTAMP literal body already
 // carries a timezone marker (offset, `Z`, or an IANA / abbreviation
 // timezone name).
@@ -1001,6 +1056,9 @@ func timestampHasTZ(s string) bool {
 	}
 	if strings.HasSuffix(s, "Z") || strings.HasSuffix(s, "z") {
 		return true
+	}
+	if dateOnly.MatchString(s) {
+		return false
 	}
 	if tzOffsetTail.MatchString(s) {
 		return true
@@ -1015,9 +1073,10 @@ func timestampHasTZ(s string) bool {
 }
 
 var (
-	timestampNeedle = regexp.MustCompile(`(?i)\bTIMESTAMP\s*['"]`)
+	timestampNeedle = regexp.MustCompile(`(?i)\bTIMESTAMP\s*['")]`)
 	// Match `[+-]HH`, `[+-]HHMM`, or `[+-]HH:MM` at the tail.
 	tzOffsetTail = regexp.MustCompile(`[+-]\d{2}(?::?\d{2})?\s*$`)
+	dateOnly     = regexp.MustCompile(`^\d{4}-\d{1,2}-\d{1,2}$`)
 	// Match a trailing alphabetic timezone identifier separated from
 	// the time component by a space (e.g. `UTC`, `GMT`,
 	// `America/Los_Angeles`, `EST`, `PST`).

--- a/regression_test.go
+++ b/regression_test.go
@@ -34,6 +34,33 @@ func TestRegression_DefaultTimezoneIsUTC(t *testing.T) {
 	}
 }
 
+func TestRegression_NaiveTimestampStringCastIsUTC(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("googlesqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	for expr, want := range map[string]string{
+		`CAST('2026-01-15 10:00:00' AS TIMESTAMP)`:                  "2026-01-15 10:00:00",
+		`SAFE_CAST("2026-01-15T10:00:00" AS TIMESTAMP)`:             "2026-01-15 10:00:00",
+		`cast ( '2026-01-15' as timestamp )`:                        "2026-01-15 00:00:00",
+		`TIMESTAMP '2026-01-15'`:                                    "2026-01-15 00:00:00",
+		`CAST('2026-01-15 10:00:00+02' AS TIMESTAMP)`:               "2026-01-15 08:00:00",
+		`CAST('2026-01-15 10:00:00 America/New_York' AS TIMESTAMP)`: "2026-01-15 15:00:00",
+	} {
+		var got string
+		if err := db.QueryRowContext(ctx, "SELECT FORMAT_TIMESTAMP('%F %T', "+expr+", 'UTC')").Scan(&got); err != nil {
+			t.Errorf("%s: %v", expr, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s = %s, want %s", expr, got, want)
+		}
+	}
+}
+
 // TestRegression_IntegerTypeAlias asserts that INTEGER and INT are accepted
 // as aliases for INT64 in DDL.
 //


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

Naive `TIMESTAMP '…'` literals are already rewritten to UTC before
analysis, but the equivalent `CAST` / `SAFE_CAST` spellings are still
folded in the analyzer's `America/Los_Angeles` default and come out shifted,
with no error. SQL generators commonly emit typed literals in exactly the
`CAST('…' AS TIMESTAMP)` form.

| SQL | got (UTC instant) | want (BigQuery) |
| -- | -- | -- |
| `CAST('2026-01-15 10:00:00' AS TIMESTAMP)` | 18:00:00 | 10:00:00 |
| `SAFE_CAST('2026-01-15T10:00:00' AS TIMESTAMP)` | 18:00:00 | 10:00:00 |
| `CAST('2026-01-15' AS TIMESTAMP)` | 08:00:00 | 00:00:00 |
| `TIMESTAMP '2026-01-15'` | 08:00:00 | 00:00:00 |
| `CAST('2026-01-15 10:00:00+02' AS TIMESTAMP)` | 08:00:00 | 08:00:00 (unchanged) |
| `TIMESTAMP('2026-01-15 10:00:00')`, `CAST(col AS TIMESTAMP)` | correct | correct (runtime paths) |

The date-only literal was missed because its trailing `-15` matched the
offset heuristic.

## Fix

In `applyNaiveTimestampUTC`, give a quoted naive date / datetime string
directly inside `CAST|SAFE_CAST( … AS TIMESTAMP)` the same explicit
`+00:00`, and expand a date-only body to midnight so it can carry the
offset. Strings that already carry an offset or zone name are untouched.

## Tests

`TestRegression_NaiveTimestampStringCastIsUTC` in `regression_test.go`
covers the spellings above (asserted through `FORMAT_TIMESTAMP(…, 'UTC')`
so the check is independent of display time zone). `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
