### PR TITLE
internal: carry NaN and ±Inf FLOAT64 values end to end

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"regexp"
@@ -89,12 +90,19 @@ func literalFromValue(v value.Value) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		value := strconv.FormatFloat(f64, 'g', -1, 64)
-		if !strings.Contains(value, ".") && !strings.Contains(value, "e") {
-			// append x.0 suffix to keep float value context
-			value = fmt.Sprintf("%s.0", value)
+		switch {
+		case math.IsInf(f64, 1):
+			return "9e999", nil
+		case math.IsInf(f64, -1):
+			return "-9e999", nil
+		case !math.IsNaN(f64):
+			value := strconv.FormatFloat(f64, 'g', -1, 64)
+			if !strings.Contains(value, ".") && !strings.Contains(value, "e") {
+				// append x.0 suffix to keep float value context
+				value = fmt.Sprintf("%s.0", value)
+			}
+			return value, nil
 		}
-		return value, nil
 	case value.BoolValue:
 		b, err := v.ToBool()
 		if err != nil {
@@ -133,7 +141,7 @@ func valueFromGoogleSQLValue(v googlesql.Value) (value.Value, error) {
 	case googlesql.TypeKindTypeBool:
 		return boolValueFromLiteral(m1(v.GetSQLLiteral()))
 	case googlesql.TypeKindTypeFloat, googlesql.TypeKindTypeDouble:
-		return floatValueFromLiteral(m1(v.GetSQLLiteral()))
+		return value.FloatValue(m1(v.ToDouble())), nil
 	case googlesql.TypeKindTypeString:
 		return value.StringValue(m1(v.StringValue())), nil
 	case googlesql.TypeKindTypeEnum:
@@ -237,14 +245,6 @@ func boolValueFromLiteral(lit string) (value.BoolValue, error) {
 		return false, err
 	}
 	return value.BoolValue(v), nil
-}
-
-func floatValueFromLiteral(lit string) (value.FloatValue, error) {
-	v, err := strconv.ParseFloat(lit, 64)
-	if err != nil {
-		return 0, err
-	}
-	return value.FloatValue(v), nil
 }
 
 func stringValueFromLiteral(lit string) (value.StringValue, error) {

--- a/internal/function_register.go
+++ b/internal/function_register.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"sync"
 
 	"github.com/goccy/go-json"
@@ -151,19 +153,32 @@ func RegisterFunctions(conn *sqlite3.Conn) error {
 		if err != nil {
 			return "", err
 		}
-		encodedValues := make([]any, 0, len(array.Values))
-		for _, value := range array.Values {
-			v, err := EncodeValue(value)
+		var b strings.Builder
+		b.WriteByte('[')
+		for i, elem := range array.Values {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			if f, ok := elem.(value.FloatValue); ok && math.IsInf(float64(f), 0) {
+				if f > 0 {
+					b.WriteString("9e999")
+				} else {
+					b.WriteString("-9e999")
+				}
+				continue
+			}
+			v, err := value.EncodeElement(elem)
 			if err != nil {
 				return "", err
 			}
-			encodedValues = append(encodedValues, v)
+			e, err := json.Marshal(v)
+			if err != nil {
+				return "", err
+			}
+			b.Write(e)
 		}
-		b, err := json.Marshal(encodedValues)
-		if err != nil {
-			return "", err
-		}
-		return string(b), err
+		b.WriteByte(']')
+		return b.String(), nil
 	}, deterministic); err != nil {
 		return fmt.Errorf("failed to register decode_array function: %w", err)
 	}

--- a/internal/value/decoder.go
+++ b/internal/value/decoder.go
@@ -101,6 +101,12 @@ func DecodeValue(v any) (Value, error) {
 
 func decodeFromValueLayout(layout *ValueLayout) (Value, error) {
 	switch layout.Header {
+	case FloatValueType:
+		f, err := strconv.ParseFloat(layout.Body, 64)
+		if err != nil {
+			return nil, err
+		}
+		return FloatValue(f), nil
 	case StringValueType:
 		return StringValue(layout.Body), nil
 	case BytesValueType:

--- a/internal/value/encoder.go
+++ b/internal/value/encoder.go
@@ -3,7 +3,9 @@ package value
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -22,12 +24,18 @@ func EncodeValue(v Value) (any, error) {
 	case IntValue:
 		return v.ToInt64()
 	case FloatValue:
-		return v.ToFloat64()
+		if !math.IsNaN(float64(vv)) {
+			return float64(vv), nil
+		}
 	case BoolValue:
 		return v.ToBool()
 	case *SafeValue:
 		return EncodeValue(vv.Value)
 	}
+	return encodeLayout(v)
+}
+
+func encodeLayout(v Value) (any, error) {
 	layout, err := valueLayoutFromValue(v)
 	if err != nil {
 		return nil, err
@@ -131,8 +139,18 @@ func ValueLayoutFromValue(v Value) (*ValueLayout, error) {
 	return valueLayoutFromValue(v)
 }
 
+// EncodeElement is EncodeValue for a value nested in a JSON body, where ±Inf cannot be a number.
+func EncodeElement(v Value) (any, error) {
+	if f, ok := v.(FloatValue); ok && math.IsInf(float64(f), 0) {
+		return encodeLayout(v)
+	}
+	return EncodeValue(v)
+}
+
 func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 	switch vv := v.(type) {
+	case FloatValue:
+		return &ValueLayout{Header: FloatValueType, Body: strconv.FormatFloat(float64(vv), 'g', -1, 64)}, nil
 	case StringValue:
 		return &ValueLayout{
 			Header: StringValueType,
@@ -211,7 +229,7 @@ func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 				values = append(values, nil)
 				continue
 			}
-			val, err := EncodeValue(v)
+			val, err := EncodeElement(v)
 			if err != nil {
 				return nil, err
 			}
@@ -228,7 +246,7 @@ func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 	case *StructValue:
 		values := make([]any, 0, len(vv.Values))
 		for _, v := range vv.Values {
-			val, err := EncodeValue(v)
+			val, err := EncodeElement(v)
 			if err != nil {
 				return nil, err
 			}

--- a/regression_test.go
+++ b/regression_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"os"
 	"testing"
 )
@@ -31,6 +32,40 @@ func TestRegression_DefaultTimezoneIsUTC(t *testing.T) {
 	}
 	if got != 12 {
 		t.Fatalf("default TZ leaks: EXTRACT(HOUR) returned %d, want 12 (UTC)", got)
+	}
+}
+
+func TestRegression_NonFiniteFloats(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("googlesqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	var isNaN, isInf, nanInArray, infInArray bool
+	var neg float64
+	if err := db.QueryRowContext(ctx, `SELECT IS_NAN(CAST('nan' AS FLOAT64)), IS_INF(IEEE_DIVIDE(o, z)), CAST('-inf' AS FLOAT64), IS_NAN(a[OFFSET(0)]), IS_INF(a[OFFSET(1)]) FROM (SELECT z, o, [IEEE_DIVIDE(z, z), IEEE_DIVIDE(o, z)] AS a FROM (SELECT 0.0 AS z, 1.0 AS o))`).Scan(&isNaN, &isInf, &neg, &nanInArray, &infInArray); err != nil {
+		t.Fatal(err)
+	}
+	if !isNaN || !isInf || !math.IsInf(neg, -1) || !nanInArray || !infInArray {
+		t.Errorf("got %v %v %v %v %v", isNaN, isInf, neg, nanInArray, infInArray)
+	}
+	rows, err := db.QueryContext(ctx, `SELECT x FROM UNNEST([3.0, IEEE_DIVIDE(1, 0), IEEE_DIVIDE(-1, 0)]) AS x ORDER BY x`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var got []float64
+	for rows.Next() {
+		var f float64
+		if err := rows.Scan(&f); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, f)
+	}
+	if len(got) != 3 || !math.IsInf(got[0], -1) || got[1] != 3 || !math.IsInf(got[2], 1) {
+		t.Errorf("ORDER BY over infinities: got %v", got)
 	}
 }
 

--- a/testdata/specs/googlesql/functions/math/ieee_divide.yaml
+++ b/testdata/specs/googlesql/functions/math/ieee_divide.yaml
@@ -11,3 +11,8 @@ cases:
     expected:
       rows:
         - [5.0]
+  - desc: division by zero yields infinities and NaN that survive as values
+    sql: SELECT IS_INF(IEEE_DIVIDE(o, z)), IEEE_DIVIDE(o, z) > 0, IS_NAN(IEEE_DIVIDE(z, z)) FROM (SELECT 1.0 AS o, 0.0 AS z)
+    expected:
+      rows:
+        - [true, true, true]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

Non-finite `FLOAT64` values do not survive:

| SQL | got | want (BigQuery) |
| -- | -- | -- |
| `SELECT CAST('nan' AS FLOAT64)` | `failed to format query …: strconv.ParseFloat: parsing "CAST(\"nan\" AS FLOAT64)": invalid syntax` | `NaN` |
| `SELECT IEEE_DIVIDE(1, 0)` (folded) | same error | `+inf` |
| `IS_NAN(IEEE_DIVIDE(z, z))`, z = 0.0 column | `false` (value is NULL) | `true` |
| `ARRAY_LENGTH([IEEE_DIVIDE(o, z), 1.0])` / `UNNEST` of it | `json: unsupported value: +Inf` | 2 |

## Cause / fix

- Folded double literals were rebuilt by parsing `GetSQLLiteral()` text,
  which is `CAST("nan" AS FLOAT64)` for non-finite values; decode through
  the numeric accessor instead.
- When generating SQL, emit ±Inf as `±9e999` and NaN through the value
  envelope; when handing values to SQLite, envelope NaN (a NaN REAL reads
  back as NULL); inside JSON bodies (arrays, structs, the `UNNEST`
  bridge) represent non-finite elements in a form JSON can carry.

Known residual: with NaN carried as an enveloped value, `ORDER BY` places
NaN after all numbers, whereas BigQuery places it first. Infinities order
correctly.

## Tests

`TestRegression_NonFiniteFloats` in `regression_test.go` (literals,
`IS_NAN`/`IS_INF`, arrays, `ORDER BY` over infinities) and
`testdata/specs/googlesql/functions/math/ieee_divide.yaml`. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
