### PR TITLE
window: honor IGNORE NULLS on FIRST_VALUE, LAST_VALUE and NTH_VALUE

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -772,6 +772,12 @@ var nativeWindowFuncMap = map[string]string{
 // safe to invoke through native OVER syntax instead of the
 // per-output-row correlated-subquery emulation. The value is the
 // custom SQLite function name registered through sqlitex.
+var ignoreNullsNativeWindowFuncs = map[string]string{
+	"first_value": "googlesqlite_window_first_value_ignore_nulls",
+	"last_value":  "googlesqlite_window_last_value_ignore_nulls",
+	"nth_value":   "googlesqlite_window_nth_value_ignore_nulls",
+}
+
 var customNativeWindowFuncMap = map[string]string{
 	"array_agg":  "googlesqlite_window_array_agg",
 	"string_agg": "googlesqlite_window_string_agg",
@@ -842,6 +848,11 @@ func (n *AnalyticFunctionCallNode) FormatSQL(ctx context.Context) (string, error
 	if m1(n.node.Distinct()) {
 		if custom, ok := distinctAwareNativeWindowFuncs[rawName]; ok {
 			return n.formatNative(ctx, custom, orderColumns, true)
+		}
+	}
+	if m1(n.node.NullHandlingModifier()) == googlesql.ResolvedNonScalarFunctionCallBaseEnums_NullHandlingModifierIgnoreNulls {
+		if custom, ok := ignoreNullsNativeWindowFuncs[rawName]; ok {
+			return n.formatNative(ctx, custom, orderColumns, false)
 		}
 	}
 	if native := nativeWindowFuncForName(rawName); native != "" && !n.requiresPredecessorEmulation() {
@@ -947,12 +958,9 @@ func (n *AnalyticFunctionCallNode) requiresPredecessorEmulation() bool {
 	case googlesql.ResolvedNonScalarFunctionCallBaseEnums_NullHandlingModifierIgnoreNulls:
 		// SQLite's SUM/AVG/COUNT/MIN/MAX/COUNT_STAR already skip
 		// NULLs unconditionally, which matches the IGNORE NULLS
-		// modifier exactly. Navigation functions (LAG/LEAD/
-		// FIRST_VALUE/LAST_VALUE/NTH_VALUE) honour the modifier
-		// natively.
+		// modifier exactly.
 		switch rawName {
-		case "sum", "count", "count_star", "avg", "min", "max",
-			"lag", "lead", "first_value", "last_value", "nth_value":
+		case "sum", "count", "count_star", "avg", "min", "max":
 			return false
 		}
 		// Custom natives parse `googlesqlite_ignore_nulls()` out of

--- a/internal/function_register.go
+++ b/internal/function_register.go
@@ -70,6 +70,9 @@ func RegisterFunctions(conn *sqlite3.Conn) error {
 		windowFuncMap["any_value"] = []*nameAndFunc{
 			{Name: "googlesqlite_window_any_value", Func: window.NewAnyValueWindowNative()},
 		}
+		windowFuncMap["first_value"] = append(windowFuncMap["first_value"], &nameAndFunc{Name: "googlesqlite_window_first_value_ignore_nulls", Func: window.NewFirstValueIgnoreNullsWindowNative()})
+		windowFuncMap["last_value"] = append(windowFuncMap["last_value"], &nameAndFunc{Name: "googlesqlite_window_last_value_ignore_nulls", Func: window.NewLastValueIgnoreNullsWindowNative()})
+		windowFuncMap["nth_value"] = append(windowFuncMap["nth_value"], &nameAndFunc{Name: "googlesqlite_window_nth_value_ignore_nulls", Func: window.NewNthValueIgnoreNullsWindowNative()})
 		windowFuncMap["corr"] = []*nameAndFunc{
 			{Name: "googlesqlite_window_corr", Func: window.NewCorrWindowNative()},
 		}

--- a/internal/functions/window/native.go
+++ b/internal/functions/window/native.go
@@ -624,3 +624,74 @@ func (a *arrayConcatAggWindowNative) Done() (any, error) {
 	}
 	return value.EncodeValue(&value.ArrayValue{Values: flattened})
 }
+
+type navigationWindowNative struct {
+	values []value.Value
+	n      int64
+	pick   func(nonNull []value.Value, n int64) value.Value
+}
+
+func NewFirstValueIgnoreNullsWindowNative() func() any {
+	return func() any {
+		return &navigationWindowNative{pick: func(vs []value.Value, _ int64) value.Value { return vs[0] }}
+	}
+}
+
+func NewLastValueIgnoreNullsWindowNative() func() any {
+	return func() any {
+		return &navigationWindowNative{pick: func(vs []value.Value, _ int64) value.Value { return vs[len(vs)-1] }}
+	}
+}
+
+func NewNthValueIgnoreNullsWindowNative() func() any {
+	return func() any {
+		return &navigationWindowNative{pick: func(vs []value.Value, n int64) value.Value {
+			if n < 1 || n > int64(len(vs)) {
+				return nil
+			}
+			return vs[n-1]
+		}}
+	}
+}
+
+func (a *navigationWindowNative) Step(stepArgs ...any) error {
+	values, err := value.ConvertArgs(stepArgs...)
+	if err != nil {
+		return err
+	}
+	values, _ = helper.ParseOptions(values...)
+	values, _ = parseWindowOptions(values...)
+	if len(values) == 0 {
+		return nil
+	}
+	if len(values) > 1 && values[1] != nil {
+		if a.n, err = values[1].ToInt64(); err != nil {
+			return err
+		}
+	}
+	a.values = append(a.values, values[0])
+	return nil
+}
+
+func (a *navigationWindowNative) Inverse(_ ...any) error {
+	if len(a.values) > 0 {
+		a.values = a.values[1:]
+	}
+	return nil
+}
+
+func (a *navigationWindowNative) Done() (any, error) {
+	nonNull := make([]value.Value, 0, len(a.values))
+	for _, v := range a.values {
+		if v != nil {
+			nonNull = append(nonNull, v)
+		}
+	}
+	if len(nonNull) == 0 {
+		return nil, nil
+	}
+	if v := a.pick(nonNull, a.n); v != nil {
+		return value.EncodeValue(v)
+	}
+	return nil, nil
+}

--- a/testdata/specs/googlesql/functions/window/first_value.yaml
+++ b/testdata/specs/googlesql/functions/window/first_value.yaml
@@ -11,3 +11,14 @@ cases:
         - [10, 10]
         - [20, 10]
         - [30, 10]
+  - desc: IGNORE NULLS picks the first non-NULL value of the frame
+    sql: |
+      SELECT t, FIRST_VALUE(x IGNORE NULLS) OVER (ORDER BY t ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS fv
+      FROM UNNEST([STRUCT(1 AS t, CAST(NULL AS STRING) AS x), (2, 'a'), (3, CAST(NULL AS STRING)), (4, 'b')])
+      ORDER BY t
+    expected:
+      rows:
+        - [1, "a"]
+        - [2, "a"]
+        - [3, "b"]
+        - [4, "b"]

--- a/testdata/specs/googlesql/functions/window/last_value.yaml
+++ b/testdata/specs/googlesql/functions/window/last_value.yaml
@@ -15,3 +15,14 @@ cases:
         - [10, 30]
         - [20, 30]
         - [30, 30]
+  - desc: IGNORE NULLS carries the last non-NULL value forward
+    sql: |
+      SELECT t, LAST_VALUE(x IGNORE NULLS) OVER (ORDER BY t) AS lv
+      FROM UNNEST([STRUCT(1 AS t, 'a' AS x), (2, CAST(NULL AS STRING)), (3, 'b'), (4, CAST(NULL AS STRING))])
+      ORDER BY t
+    expected:
+      rows:
+        - [1, "a"]
+        - [2, "a"]
+        - [3, "b"]
+        - [4, "b"]

--- a/testdata/specs/googlesql/functions/window/nth_value.yaml
+++ b/testdata/specs/googlesql/functions/window/nth_value.yaml
@@ -6,3 +6,13 @@ cases:
     expected:
       rows:
         - [20]
+  - desc: IGNORE NULLS counts only non-NULL values
+    sql: |
+      SELECT t, NTH_VALUE(x, 2 IGNORE NULLS) OVER (ORDER BY t ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS nv
+      FROM UNNEST([STRUCT(1 AS t, 'a' AS x), (2, CAST(NULL AS STRING)), (3, 'b')])
+      ORDER BY t
+    expected:
+      rows:
+        - [1, "b"]
+        - [2, "b"]
+        - [3, "b"]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

`IGNORE NULLS` on `FIRST_VALUE`, `LAST_VALUE` and `NTH_VALUE` is silently
dropped:

```sql
SELECT t, LAST_VALUE(x IGNORE NULLS) OVER (ORDER BY t) AS lv
FROM UNNEST([STRUCT(1 AS t, 'a' AS x), (2, CAST(NULL AS STRING)), (3, 'b'), (4, CAST(NULL AS STRING))])
-- got:  a, NULL, b, NULL
-- want: a, a,    b, b      (BigQuery)
```

## Cause

The three navigation functions are emitted as SQLite's built-in window
functions on the assumption that those honour the modifier; SQLite has no
`IGNORE NULLS`, so the marker never reaches anything.

## Fix

Add frame-driven natives (`Step`/`Inverse`/`Done` over the active frame,
same shape as the existing `ANY_VALUE` native) that pick the first / last
/ n-th non-NULL value, and route the `IGNORE NULLS` forms of the three
functions to them. `RESPECT NULLS` / no modifier keep the SQLite built-ins.
Verified against BigQuery for the default frame, explicit ROWS frames,
partitions and `NTH_VALUE`.

## Tests

Spec cases in `testdata/specs/googlesql/functions/window/{first_value,last_value,nth_value}.yaml`. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
