### PR TITLE
json: look subscript keys up directly and quote JSON_KEYS output like BigQuery

### DIFF
--- a/internal/functions/json/json_bind_test.go
+++ b/internal/functions/json/json_bind_test.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -459,6 +460,37 @@ func TestBindJsonType(t *testing.T) {
 	}
 }
 
+func TestJsonSubscriptByRuntimeKey(t *testing.T) {
+	t.Parallel()
+
+	doc := value.JsonValue(`{"ns::name": 1, "a.b": {"x": [7]}, "arr": [1, {"k": 2}]}`)
+	for _, tc := range []struct {
+		field value.Value
+		want  string
+	}{
+		{value.StringValue("ns::name"), "1"},
+		{value.StringValue("a.b"), `{"x": [7]}`},
+		{value.StringValue(`"a.b"`), ""},
+		{value.StringValue("missing"), ""},
+		{value.IntValue(0), ""},
+	} {
+		got, err := BindSubscript(doc, tc.field)
+		if err != nil {
+			t.Fatalf("subscript %v: %v", tc.field, err)
+		}
+		if s := fmt.Sprint(got); (tc.want == "" && got != nil) || (tc.want != "" && s != tc.want) {
+			t.Errorf("subscript %v = %v, want %q", tc.field, got, tc.want)
+		}
+	}
+	arr, _ := BindSubscript(doc, value.StringValue("arr"))
+	if got, _ := BindSubscript(arr, value.IntValue(1)); fmt.Sprint(got) != `{"k": 2}` {
+		t.Errorf("arr[1] = %v", got)
+	}
+	if got, _ := BindSubscript(arr, value.IntValue(5)); got != nil {
+		t.Errorf("arr[5] = %v, want NULL", got)
+	}
+}
+
 func TestBindJsonKeys(t *testing.T) {
 	t.Parallel()
 
@@ -516,14 +548,13 @@ func TestBindJsonKeys(t *testing.T) {
 		t.Fatalf("lax should include array-nested key: %v", arr.Values)
 	}
 
-	// Special-character key gets quoted.
-	got, err = BindJsonKeys(value.StringValue(`{"a b":1}`))
+	got, err = BindJsonKeys(value.StringValue(`{"a b":1, "k:v":2, "a.b":{"c":3}}`))
 	if err != nil {
 		t.Fatal(err)
 	}
 	arr = mustArray(t, got)
-	if mustString(t, arr.Values[0]) != `"a b"` {
-		t.Fatalf("got %q", mustString(t, arr.Values[0]))
+	if fmt.Sprint(arr.Values) != `["a.b" "a.b".c a b k:v]` {
+		t.Fatalf("got %v", arr.Values)
 	}
 
 	// Invalid JSON -> error.

--- a/internal/functions/json/json_keys.go
+++ b/internal/functions/json/json_keys.go
@@ -90,34 +90,15 @@ func (c *jsonKeysCollector) walk(node any, path string, depth int, insideArray b
 	}
 }
 
-// joinJSONKey appends `key` onto `parent`, quoting keys that contain
-// non-identifier characters per the spec ("Keys containing special
-// characters are escaped using double quotes").
 func joinJSONKey(parent, key string) string {
 	out := key
-	if needsJSONKeyQuote(key) {
+	if strings.ContainsAny(key, `."`) {
 		out = strconv.Quote(key)
 	}
 	if parent == "" {
 		return out
 	}
 	return parent + "." + out
-}
-
-func needsJSONKeyQuote(s string) bool {
-	if s == "" {
-		return true
-	}
-	for i, r := range s {
-		if r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-			continue
-		}
-		if i > 0 && r >= '0' && r <= '9' {
-			continue
-		}
-		return true
-	}
-	return false
 }
 
 // BindJsonKeys parses positional args and any kwargs the analyzer

--- a/internal/functions/json/json_subscript.go
+++ b/internal/functions/json/json_subscript.go
@@ -1,45 +1,33 @@
 package json
 
 import (
-	"fmt"
-
 	"github.com/goccy/go-json"
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
 func JSON_SUBSCRIPT(v string, field value.Value) (value.Value, error) {
-	var path *json.Path
-	switch field.(type) {
+	var raw json.RawMessage
+	switch f := field.(type) {
 	case value.IntValue:
-		index, err := field.ToInt64()
-		if err != nil {
-			return nil, err
+		var elems []json.RawMessage
+		if err := json.Unmarshal([]byte(v), &elems); err != nil || f < 0 || int(f) >= len(elems) {
+			return nil, nil
 		}
-		p, err := json.CreatePath(fmt.Sprintf(`$[%d]`, index))
-		if err != nil {
-			return nil, err
-		}
-		path = p
+		raw = elems[f]
 	case value.StringValue:
-		name, err := field.ToString()
-		if err != nil {
-			return nil, err
+		var members map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(v), &members); err != nil {
+			return nil, nil
 		}
-		p, err := json.CreatePath(fmt.Sprintf(`$.%q`, name))
-		if err != nil {
-			return nil, err
+		var ok bool
+		if raw, ok = members[string(f)]; !ok {
+			return nil, nil
 		}
-		path = p
-	}
-	extracted, err := path.Extract([]byte(v))
-	if err != nil {
-		return nil, err
-	}
-	if len(extracted) == 0 {
+	default:
 		return nil, nil
 	}
-	return value.JsonValue(string(extracted[0])), nil
+	return value.JsonValue(string(raw)), nil
 }
 
 var BindSubscript = helper.Scalar2(func(a, b value.Value) (value.Value, error) {

--- a/testdata/specs/bigquery/functions/json/json_keys.yaml
+++ b/testdata/specs/bigquery/functions/json/json_keys.yaml
@@ -21,3 +21,10 @@ cases:
     expected:
       rows:
         - ['["a"]']
+  - desc: only keys containing a dot or a double quote are escaped, and keys round-trip through subscript
+    sql: |
+      SELECT TO_JSON_STRING(JSON_KEYS(j, 1)), TO_JSON_STRING(ARRAY(SELECT j[k] FROM UNNEST(JSON_KEYS(j, 1)) AS k WHERE j[k] IS NOT NULL ORDER BY k))
+      FROM (SELECT JSON '{"k:v": 2, "a b": 1, "a.b": 3}' AS j)
+    expected:
+      rows:
+        - ['["\"a.b\"","a b","k:v"]', "[1,2]"]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

Subscripting a JSON value with a key obtained at run time fails for keys
that are not plain identifiers, and `JSON_KEYS` quotes more keys than
BigQuery does:

```sql
SELECT k, j[k]
FROM (SELECT JSON '{"k:v": 1, "a b": 2, "a.b": 3}' AS j) CROSS JOIN UNNEST(JSON_KEYS(j, 1)) AS k
-- got:  json: invalid path format: expect dot or left bracket character…
-- want: "a.b" → NULL, a b → 2, k:v → 1        (BigQuery)

SELECT JSON_KEYS(JSON '{"z":1, "a b":1, "a-b":1, "1a":1, "":1, "a.b":{"c.d":2}, "k:v":1}')
-- got:  ["", "1a", "a b", "a-b", "a.b"."c.d", …] with every non-identifier key double-quoted
-- want: [, "a.b", "a.b"."c.d", 1a, a b, a-b, k:v, z]   (only keys containing '.' or '"' are quoted)
```

## Cause / fix

- `JSON_KEYS` quoted any key that is not an identifier; BigQuery quotes
  only keys containing `.` or `"`. Follow that rule.
- The subscript operator turned the key text into a JSONPath (`$."<key>"`)
  and re-parsed it, which breaks for keys carrying quotes. Resolve a string
  key as an object member and an integer as an array element directly;
  a missing member, out-of-range index or non-container value is NULL.

## Tests

`internal/functions/json/json_bind_test.go` (subscript by runtime key,
JSON_KEYS quoting) and `testdata/specs/bigquery/functions/json/json_keys.yaml`
(quoting rule + subscript round trip). `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after. Values confirmed against BigQuery.
