### PR TITLE
value: keep FLOAT64 elements of arrays and structs FLOAT64 across the codec

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"regexp"
@@ -89,12 +90,19 @@ func literalFromValue(v value.Value) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		value := strconv.FormatFloat(f64, 'g', -1, 64)
-		if !strings.Contains(value, ".") && !strings.Contains(value, "e") {
-			// append x.0 suffix to keep float value context
-			value = fmt.Sprintf("%s.0", value)
+		switch {
+		case math.IsInf(f64, 1):
+			return "9e999", nil
+		case math.IsInf(f64, -1):
+			return "-9e999", nil
+		case !math.IsNaN(f64):
+			value := strconv.FormatFloat(f64, 'g', -1, 64)
+			if !strings.Contains(value, ".") && !strings.Contains(value, "e") {
+				// append x.0 suffix to keep float value context
+				value = fmt.Sprintf("%s.0", value)
+			}
+			return value, nil
 		}
-		return value, nil
 	case value.BoolValue:
 		b, err := v.ToBool()
 		if err != nil {
@@ -133,7 +141,7 @@ func valueFromGoogleSQLValue(v googlesql.Value) (value.Value, error) {
 	case googlesql.TypeKindTypeBool:
 		return boolValueFromLiteral(m1(v.GetSQLLiteral()))
 	case googlesql.TypeKindTypeFloat, googlesql.TypeKindTypeDouble:
-		return floatValueFromLiteral(m1(v.GetSQLLiteral()))
+		return value.FloatValue(m1(v.ToDouble())), nil
 	case googlesql.TypeKindTypeString:
 		return value.StringValue(m1(v.StringValue())), nil
 	case googlesql.TypeKindTypeEnum:
@@ -237,14 +245,6 @@ func boolValueFromLiteral(lit string) (value.BoolValue, error) {
 		return false, err
 	}
 	return value.BoolValue(v), nil
-}
-
-func floatValueFromLiteral(lit string) (value.FloatValue, error) {
-	v, err := strconv.ParseFloat(lit, 64)
-	if err != nil {
-		return 0, err
-	}
-	return value.FloatValue(v), nil
 }
 
 func stringValueFromLiteral(lit string) (value.StringValue, error) {

--- a/internal/function_register.go
+++ b/internal/function_register.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"sync"
 
 	"github.com/goccy/go-json"
@@ -151,19 +153,32 @@ func RegisterFunctions(conn *sqlite3.Conn) error {
 		if err != nil {
 			return "", err
 		}
-		encodedValues := make([]any, 0, len(array.Values))
-		for _, value := range array.Values {
-			v, err := EncodeValue(value)
+		var b strings.Builder
+		b.WriteByte('[')
+		for i, elem := range array.Values {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			if f, ok := elem.(value.FloatValue); ok && math.IsInf(float64(f), 0) {
+				if f > 0 {
+					b.WriteString("9e999")
+				} else {
+					b.WriteString("-9e999")
+				}
+				continue
+			}
+			v, err := value.EncodeElement(elem)
 			if err != nil {
 				return "", err
 			}
-			encodedValues = append(encodedValues, v)
+			e, err := json.Marshal(v)
+			if err != nil {
+				return "", err
+			}
+			b.Write(e)
 		}
-		b, err := json.Marshal(encodedValues)
-		if err != nil {
-			return "", err
-		}
-		return string(b), err
+		b.WriteByte(']')
+		return b.String(), nil
 	}, deterministic); err != nil {
 		return fmt.Errorf("failed to register decode_array function: %w", err)
 	}

--- a/internal/value/decoder.go
+++ b/internal/value/decoder.go
@@ -101,6 +101,12 @@ func DecodeValue(v any) (Value, error) {
 
 func decodeFromValueLayout(layout *ValueLayout) (Value, error) {
 	switch layout.Header {
+	case FloatValueType:
+		f, err := strconv.ParseFloat(layout.Body, 64)
+		if err != nil {
+			return nil, err
+		}
+		return FloatValue(f), nil
 	case StringValueType:
 		return StringValue(layout.Body), nil
 	case BytesValueType:

--- a/internal/value/encoder.go
+++ b/internal/value/encoder.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -139,10 +140,17 @@ func ValueLayoutFromValue(v Value) (*ValueLayout, error) {
 	return valueLayoutFromValue(v)
 }
 
-// EncodeElement is EncodeValue for a value nested in a JSON body, where ±Inf cannot be a number.
+// EncodeElement is EncodeValue for a value nested in a JSON body.
 func EncodeElement(v Value) (any, error) {
-	if f, ok := v.(FloatValue); ok && math.IsInf(float64(f), 0) {
-		return encodeLayout(v)
+	if f, ok := v.(FloatValue); ok && !math.IsNaN(float64(f)) {
+		if math.IsInf(float64(f), 0) {
+			return encodeLayout(v)
+		}
+		s := strconv.FormatFloat(float64(f), 'g', -1, 64)
+		if !strings.ContainsAny(s, ".eE") {
+			s += ".0"
+		}
+		return json.RawMessage(s), nil
 	}
 	return EncodeValue(v)
 }

--- a/internal/value/encoder.go
+++ b/internal/value/encoder.go
@@ -3,7 +3,9 @@ package value
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -22,12 +24,18 @@ func EncodeValue(v Value) (any, error) {
 	case IntValue:
 		return v.ToInt64()
 	case FloatValue:
-		return v.ToFloat64()
+		if !math.IsNaN(float64(vv)) {
+			return float64(vv), nil
+		}
 	case BoolValue:
 		return v.ToBool()
 	case *SafeValue:
 		return EncodeValue(vv.Value)
 	}
+	return encodeLayout(v)
+}
+
+func encodeLayout(v Value) (any, error) {
 	layout, err := valueLayoutFromValue(v)
 	if err != nil {
 		return nil, err
@@ -131,8 +139,18 @@ func ValueLayoutFromValue(v Value) (*ValueLayout, error) {
 	return valueLayoutFromValue(v)
 }
 
+// EncodeElement is EncodeValue for a value nested in a JSON body, where ±Inf cannot be a number.
+func EncodeElement(v Value) (any, error) {
+	if f, ok := v.(FloatValue); ok && math.IsInf(float64(f), 0) {
+		return encodeLayout(v)
+	}
+	return EncodeValue(v)
+}
+
 func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 	switch vv := v.(type) {
+	case FloatValue:
+		return &ValueLayout{Header: FloatValueType, Body: strconv.FormatFloat(float64(vv), 'g', -1, 64)}, nil
 	case StringValue:
 		return &ValueLayout{
 			Header: StringValueType,
@@ -211,7 +229,7 @@ func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 				values = append(values, nil)
 				continue
 			}
-			val, err := EncodeValue(v)
+			val, err := EncodeElement(v)
 			if err != nil {
 				return nil, err
 			}
@@ -228,7 +246,7 @@ func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 	case *StructValue:
 		values := make([]any, 0, len(vv.Values))
 		for _, v := range vv.Values {
-			val, err := EncodeValue(v)
+			val, err := EncodeElement(v)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/value/value_array_test.go
+++ b/internal/value/value_array_test.go
@@ -179,3 +179,29 @@ func TestArrayValue(t *testing.T) {
 		}
 	})
 }
+
+func TestIntegralFloatInsideArrayAndStructKeepsItsType(t *testing.T) {
+	arr := &value.ArrayValue{Values: []value.Value{value.FloatValue(3), value.FloatValue(2.5), value.IntValue(4)}}
+	enc, err := value.EncodeValue(arr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := value.DecodeValue(enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := dec.ToArray()
+	if _, ok := got.Values[0].(value.FloatValue); !ok {
+		t.Errorf("array element 3.0 decoded as %T, want FloatValue", got.Values[0])
+	}
+	if _, ok := got.Values[2].(value.IntValue); !ok {
+		t.Errorf("array element 4 decoded as %T, want IntValue", got.Values[2])
+	}
+	st := &value.StructValue{Keys: []string{"f"}, Values: []value.Value{value.FloatValue(7)}}
+	enc, _ = value.EncodeValue(st)
+	dec, _ = value.DecodeValue(enc)
+	sv, _ := dec.ToStruct()
+	if _, ok := sv.Values[0].(value.FloatValue); !ok {
+		t.Errorf("struct field 7.0 decoded as %T, want FloatValue", sv.Values[0])
+	}
+}

--- a/regression_test.go
+++ b/regression_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"os"
 	"testing"
 )
@@ -31,6 +32,40 @@ func TestRegression_DefaultTimezoneIsUTC(t *testing.T) {
 	}
 	if got != 12 {
 		t.Fatalf("default TZ leaks: EXTRACT(HOUR) returned %d, want 12 (UTC)", got)
+	}
+}
+
+func TestRegression_NonFiniteFloats(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("googlesqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	var isNaN, isInf, nanInArray, infInArray bool
+	var neg float64
+	if err := db.QueryRowContext(ctx, `SELECT IS_NAN(CAST('nan' AS FLOAT64)), IS_INF(IEEE_DIVIDE(o, z)), CAST('-inf' AS FLOAT64), IS_NAN(a[OFFSET(0)]), IS_INF(a[OFFSET(1)]) FROM (SELECT z, o, [IEEE_DIVIDE(z, z), IEEE_DIVIDE(o, z)] AS a FROM (SELECT 0.0 AS z, 1.0 AS o))`).Scan(&isNaN, &isInf, &neg, &nanInArray, &infInArray); err != nil {
+		t.Fatal(err)
+	}
+	if !isNaN || !isInf || !math.IsInf(neg, -1) || !nanInArray || !infInArray {
+		t.Errorf("got %v %v %v %v %v", isNaN, isInf, neg, nanInArray, infInArray)
+	}
+	rows, err := db.QueryContext(ctx, `SELECT x FROM UNNEST([3.0, IEEE_DIVIDE(1, 0), IEEE_DIVIDE(-1, 0)]) AS x ORDER BY x`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var got []float64
+	for rows.Next() {
+		var f float64
+		if err := rows.Scan(&f); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, f)
+	}
+	if len(got) != 3 || !math.IsInf(got[0], -1) || got[1] != 3 || !math.IsInf(got[2], 1) {
+		t.Errorf("ORDER BY over infinities: got %v", got)
 	}
 }
 

--- a/testdata/specs/googlesql/functions/math/ieee_divide.yaml
+++ b/testdata/specs/googlesql/functions/math/ieee_divide.yaml
@@ -11,3 +11,8 @@ cases:
     expected:
       rows:
         - [5.0]
+  - desc: division by zero yields infinities and NaN that survive as values
+    sql: SELECT IS_INF(IEEE_DIVIDE(o, z)), IEEE_DIVIDE(o, z) > 0, IS_NAN(IEEE_DIVIDE(z, z)) FROM (SELECT 1.0 AS o, 0.0 AS z)
+    expected:
+      rows:
+        - [true, true, true]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

Stacked on #63 (it edits the element encoder introduced there); the change on top of #63 is the last commit only.

## Problem

An integral `FLOAT64` nested in an `ARRAY` or `STRUCT` comes back as
`INT64`, which shows wherever the element's type matters:

| SQL (x = 3.0) | got | want (BigQuery) |
| -- | -- | -- |
| `FORMAT('%t', [x, 2.5])` | `[3, 2.5]` | `[3.0, 2.5]` |
| `FORMAT('%t', STRUCT(x AS a, 'q' AS b))` | `(3, q)` | `(3.0, q)` |
| `FORMAT('%t', e)` over `UNNEST([3.0, 2.5]) e` | `3`, `2.5` | `3.0`, `2.5` |

## Cause / fix

Array / struct bodies are JSON; a float64 element was marshalled as `3`
and decoded as an integer. Nested finite doubles are now written with a
fractional part (`3.0`) so they decode as `FLOAT64` again (the `UNNEST`
bridge reads them back as REAL too).

## Tests

`internal/value/value_array_test.go` round-trips arrays and structs and
asserts the element types. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
