### PR TITLE
string: support `_` and backslash escapes in LIKE

### DIFF
--- a/internal/functions/string/bind_test.go
+++ b/internal/functions/string/bind_test.go
@@ -576,6 +576,35 @@ func TestLike(t *testing.T) {
 	if b, _ := got.ToBool(); b {
 		t.Errorf("LIKE non-match expected FALSE")
 	}
+	for _, tc := range []struct {
+		v, p value.Value
+		want bool
+	}{
+		{value.StringValue("abc"), value.StringValue("ab_"), true},
+		{value.StringValue("ab"), value.StringValue("ab_"), false},
+		{value.StringValue("щ"), value.StringValue("_"), true},
+		{value.StringValue("a\nb"), value.StringValue("a_b"), true},
+		{value.StringValue("a_c"), value.StringValue(`a\_c`), true},
+		{value.StringValue("abc"), value.StringValue(`a\_c`), false},
+		{value.StringValue("a%c"), value.StringValue(`a\%c`), true},
+		{value.StringValue(`a\c`), value.StringValue(`a\\c`), true},
+		{value.StringValue("abc"), value.StringValue("a.c"), false},
+		{value.StringValue("a(b"), value.StringValue("a(_"), true},
+		{value.BytesValue("\xd1\x89"), value.BytesValue("__"), true},
+		{value.BytesValue("abc"), value.BytesValue("a_c"), true},
+	} {
+		got, err := strfn.BindLike(tc.v, tc.p)
+		if err != nil {
+			t.Errorf("%v LIKE %v: %v", tc.v, tc.p, err)
+			continue
+		}
+		if b, _ := got.ToBool(); b != tc.want {
+			t.Errorf("%v LIKE %v = %v, want %v", tc.v, tc.p, b, tc.want)
+		}
+	}
+	if _, err := strfn.BindLike(value.StringValue("x"), value.StringValue(`a\`)); err == nil {
+		t.Errorf("a pattern ending in a backslash must fail")
+	}
 }
 
 func TestRegexpFamily(t *testing.T) {

--- a/internal/functions/string/like.go
+++ b/internal/functions/string/like.go
@@ -4,27 +4,69 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/goccy/googlesqlite/internal/functions/helper"
 	"github.com/goccy/googlesqlite/internal/value"
 )
 
 func LIKE(a, b value.Value) (value.Value, error) {
-	va, err := a.ToString()
-	if err != nil {
-		return nil, err
+	var va, vb string
+	if ba, ok := a.(value.BytesValue); ok {
+		bb, err := b.ToBytes()
+		if err != nil {
+			return nil, err
+		}
+		va, vb = latin1(ba), latin1(bb)
+	} else {
+		var err error
+		if va, err = a.ToString(); err != nil {
+			return nil, err
+		}
+		if vb, err = b.ToString(); err != nil {
+			return nil, err
+		}
 	}
-	vb, err := b.ToString()
-	if err != nil {
-		return nil, err
-	}
-	wildcard := strings.ReplaceAll(regexp.QuoteMeta(vb), "%", ".*")
-	matchLimits := fmt.Sprintf("^%s$", wildcard)
-	re, err := regexp.Compile(matchLimits)
+	re, err := likePatternToRegexp(vb)
 	if err != nil {
 		return nil, err
 	}
 	return value.BoolValue(re.MatchString(va)), nil
+}
+
+// latin1 maps each byte to one rune so BYTES operands match byte-wise.
+func latin1(bs []byte) string {
+	rs := make([]rune, len(bs))
+	for i, c := range bs {
+		rs[i] = rune(c)
+	}
+	return string(rs)
+}
+
+func likePatternToRegexp(pattern string) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteString("(?s)^")
+	for i := 0; i < len(pattern); {
+		r, n := utf8.DecodeRuneInString(pattern[i:])
+		switch r {
+		case '%':
+			b.WriteString(".*")
+		case '_':
+			b.WriteString(".")
+		case '\\':
+			if i+n == len(pattern) {
+				return nil, fmt.Errorf("LIKE pattern ends with a backslash")
+			}
+			i += n
+			r, n = utf8.DecodeRuneInString(pattern[i:])
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		default:
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		}
+		i += n
+	}
+	b.WriteString("$")
+	return regexp.Compile(b.String())
 }
 
 // BindLike: per GoogleSQL three-valued logic, LIKE with a NULL operand

--- a/testdata/specs/googlesql/syntax/query/predicates.yaml
+++ b/testdata/specs/googlesql/syntax/query/predicates.yaml
@@ -26,6 +26,11 @@ cases:
     expected:
       rows:
         - [true, false]
+  - desc: LIKE single-character wildcard and escapes
+    sql: SELECT 'abc' LIKE 'ab_', 'ab' LIKE 'ab_', 'a_c' LIKE 'a\\_c', 'abc' LIKE 'a\\_c', 'a%c' LIKE r'a\%c', 'abc' LIKE 'a.c', b'abc' LIKE b'a_c'
+    expected:
+      rows:
+        - [true, false, true, false, true, false, true]
   - desc: EXISTS subquery
     sql: |-
       SELECT


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

`LIKE` only implements `%`. `_` is matched literally and backslash
escapes are not honored, so these are all silently wrong:

| SQL | got | want (BigQuery) |
| -- | -- | -- |
| `'abc' LIKE 'ab_'`, `'abc' LIKE '___'` | false | true |
| `'a_c' LIKE 'a\\_c'` | false | true |
| `'abc' LIKE 'a\\_c'` | false | false |
| `'a%c' LIKE 'a\\%c'` | false | true |
| `'a\\c' LIKE 'a\\\\c'` | false | true |
| `'a\nb' LIKE 'a_b'` | false | true |
| `b'\xd1\x89' LIKE b'__'` (2 bytes) | false | true |
| `'abc' LIKE 'a.c'` | false | false (unchanged) |

## Cause / fix

`internal/functions/string/like.go` quoted the whole pattern and replaced
`%` only. Translate element by element per operators.md#like_operator:
`%` → `.*`, `_` → `.`, `\x` → literal `x` (a trailing backslash is
an error), everything else quoted; single-line mode so a newline is an
ordinary character; BYTES operands match byte-wise.

## Tests

`internal/functions/string/bind_test.go` (table incl. BYTES and the
trailing-backslash error) and
`testdata/specs/googlesql/syntax/query/predicates.yaml`. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after. The table above
was confirmed against BigQuery.
