### PR TITLE
conditional: NULLIF with a NULL match value returns the first argument

### DIFF
--- a/internal/functions/conditional/conditional_test.go
+++ b/internal/functions/conditional/conditional_test.go
@@ -142,6 +142,16 @@ func TestBindNullIfDifferent(t *testing.T) {
 	}
 }
 
+func TestBindNullIfMatchNull(t *testing.T) {
+	got, err := BindNullIf(value.StringValue("a"), nil)
+	if err != nil {
+		t.Fatalf("BindNullIf: %v", err)
+	}
+	if got != value.Value(value.StringValue("a")) {
+		t.Fatalf("NULLIF('a', NULL) = %v, want 'a'", got)
+	}
+}
+
 // TestBindNullIfExprNull: NULLIF(NULL, x) returns NULL.
 func TestBindNullIfExprNull(t *testing.T) {
 	got, err := BindNullIf(nil, value.IntValue(5))

--- a/internal/functions/conditional/nullif.go
+++ b/internal/functions/conditional/nullif.go
@@ -6,8 +6,8 @@ import (
 )
 
 func NULLIF(expr, exprToMatch value.Value) (value.Value, error) {
-	if expr == nil {
-		return nil, nil
+	if expr == nil || exprToMatch == nil {
+		return expr, nil
 	}
 	cond, err := expr.EQ(exprToMatch)
 	if err != nil {

--- a/testdata/specs/googlesql/syntax/query/conditional_expressions.yaml
+++ b/testdata/specs/googlesql/syntax/query/conditional_expressions.yaml
@@ -31,3 +31,8 @@ cases:
     expected:
       rows:
         - [null, 1]
+  - desc: NULLIF with a NULL match value returns the first argument
+    sql: SELECT NULLIF('a', y), NULLIF(y, 'a') FROM (SELECT CAST(NULL AS STRING) AS y)
+    expected:
+      rows:
+        - ["a", null]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

```sql
SELECT NULLIF('a', y) FROM (SELECT CAST(NULL AS STRING) AS y)
-- got:  runtime error: invalid memory address or nil pointer dereference
-- want: 'a'   (BigQuery; NULLIF(NULL, x) stays NULL)
```

## Cause / fix

`NULLIF` compared its first argument against a NULL second argument and
dereferenced the NULL. Nothing equals NULL, so the first argument is
returned unchanged when the match value is NULL.

## Tests

`internal/functions/conditional/conditional_test.go` and
`testdata/specs/googlesql/syntax/query/conditional_expressions.yaml`. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
