### PR TITLE
value: keep fractional seconds when FORMAT %t / %T renders a TIMESTAMP

### DIFF
--- a/internal/cast_test.go
+++ b/internal/cast_test.go
@@ -3,6 +3,9 @@ package internal
 import (
 	"strings"
 	"testing"
+	gotime "time"
+
+	"github.com/goccy/go-googlesql"
 
 	"github.com/goccy/googlesqlite/internal/value"
 )
@@ -88,5 +91,28 @@ func TestBindCast_HappyPath(t *testing.T) {
 	s, _ := got.ToString()
 	if !strings.Contains(s, "42") {
 		t.Fatalf("expected result containing 42, got %q", s)
+	}
+}
+
+func TestCastTimestampToStringCanonicalForm(t *testing.T) {
+	for _, tc := range []struct {
+		in   gotime.Time
+		want string
+	}{
+		{gotime.Date(2026, 8, 7, 22, 0, 0, 0, gotime.UTC), "2026-08-07 22:00:00+00"},
+		{gotime.Date(2020, 1, 1, 0, 0, 0, 500000000, gotime.UTC), "2020-01-01 00:00:00.500+00"},
+		{gotime.Date(2020, 1, 1, 0, 0, 0, 123400000, gotime.UTC), "2020-01-01 00:00:00.123400+00"},
+		{gotime.Date(2020, 1, 1, 3, 0, 0, 0, gotime.FixedZone("", 3*3600)), "2020-01-01 00:00:00+00"},
+	} {
+		if got := castTimestampToString(tc.in); got != tc.want {
+			t.Errorf("castTimestampToString(%v): got %q, want %q", tc.in, got, tc.want)
+		}
+		got, err := CastValue(m1(tf().MakeSimpleType(googlesql.TypeKindTypeString)), value.TimestampValue(tc.in))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != value.Value(value.StringValue(tc.want)) {
+			t.Errorf("CastValue(STRING, TIMESTAMP %v): got %#v, want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/internal/cast_test.go
+++ b/internal/cast_test.go
@@ -104,8 +104,8 @@ func TestCastTimestampToStringCanonicalForm(t *testing.T) {
 		{gotime.Date(2020, 1, 1, 0, 0, 0, 123400000, gotime.UTC), "2020-01-01 00:00:00.123400+00"},
 		{gotime.Date(2020, 1, 1, 3, 0, 0, 0, gotime.FixedZone("", 3*3600)), "2020-01-01 00:00:00+00"},
 	} {
-		if got := castTimestampToString(tc.in); got != tc.want {
-			t.Errorf("castTimestampToString(%v): got %q, want %q", tc.in, got, tc.want)
+		if got := value.TimestampValue(tc.in).Format('t'); got != tc.want {
+			t.Errorf("Format('t') of %v: got %q, want %q", tc.in, got, tc.want)
 		}
 		got, err := CastValue(m1(tf().MakeSimpleType(googlesql.TypeKindTypeString)), value.TimestampValue(tc.in))
 		if err != nil {

--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -491,7 +491,7 @@ func CastValue(t googlesql.Googlesql_TypeNode, v value.Value) (value.Value, erro
 		return value.FloatValue(f64), nil
 	case googlesql.TypeKindTypeString, googlesql.TypeKindTypeEnum:
 		if ts, ok := v.(value.TimestampValue); ok {
-			return value.StringValue(castTimestampToString(time.Time(ts))), nil
+			return value.StringValue(ts.CanonicalString()), nil
 		}
 		s, err := v.ToString()
 		if err != nil {
@@ -762,16 +762,4 @@ func encodeValueAgainstParamType(v any, t googlesql.Googlesql_TypeNode) (any, er
 		}
 	}
 	return encodeGoValue(t, v)
-}
-
-func castTimestampToString(t time.Time) string {
-	t = t.UTC()
-	switch us := t.Nanosecond() / 1000; {
-	case us == 0:
-		return t.Format("2006-01-02 15:04:05+00")
-	case us%1000 == 0:
-		return t.Format("2006-01-02 15:04:05.000+00")
-	default:
-		return t.Format("2006-01-02 15:04:05.000000+00")
-	}
 }

--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -490,6 +490,9 @@ func CastValue(t googlesql.Googlesql_TypeNode, v value.Value) (value.Value, erro
 		}
 		return value.FloatValue(f64), nil
 	case googlesql.TypeKindTypeString, googlesql.TypeKindTypeEnum:
+		if ts, ok := v.(value.TimestampValue); ok {
+			return value.StringValue(castTimestampToString(time.Time(ts))), nil
+		}
 		s, err := v.ToString()
 		if err != nil {
 			return nil, err
@@ -759,4 +762,16 @@ func encodeValueAgainstParamType(v any, t googlesql.Googlesql_TypeNode) (any, er
 		}
 	}
 	return encodeGoValue(t, v)
+}
+
+func castTimestampToString(t time.Time) string {
+	t = t.UTC()
+	switch us := t.Nanosecond() / 1000; {
+	case us == 0:
+		return t.Format("2006-01-02 15:04:05+00")
+	case us%1000 == 0:
+		return t.Format("2006-01-02 15:04:05.000+00")
+	default:
+		return t.Format("2006-01-02 15:04:05.000000+00")
+	}
 }

--- a/internal/value/value_timestamp.go
+++ b/internal/value/value_timestamp.go
@@ -160,9 +160,21 @@ func (t TimestampValue) ToRat() (*big.Rat, error) {
 	return nil, fmt.Errorf("failed to convert *big.Rat from timestamp %v", t)
 }
 
+// CanonicalString is the CAST(TIMESTAMP AS STRING) form.
+func (t TimestampValue) CanonicalString() string {
+	u := time.Time(t).UTC()
+	switch us := u.Nanosecond() / 1000; {
+	case us == 0:
+		return u.Format("2006-01-02 15:04:05+00")
+	case us%1000 == 0:
+		return u.Format("2006-01-02 15:04:05.000+00")
+	default:
+		return u.Format("2006-01-02 15:04:05.000000+00")
+	}
+}
+
 func (t TimestampValue) Format(verb rune) string {
-	const timestampPrintableFormat = "2006-01-02 15:04:05"
-	formatted := time.Time(t).UTC().Format(timestampPrintableFormat) + "+00"
+	formatted := t.CanonicalString()
 	switch verb {
 	case 't':
 		return formatted

--- a/testdata/specs/googlesql/functions/string/format.yaml
+++ b/testdata/specs/googlesql/functions/string/format.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - ['00042']
+  - desc: '%t and %T keep the fractional seconds of a TIMESTAMP'
+    sql: SELECT FORMAT('%t|%T', t, t) FROM (SELECT TIMESTAMP '2026-08-17 22:37:14.701047+00' AS t)
+    expected:
+      rows:
+        - ['2026-08-17 22:37:14.701047+00|TIMESTAMP "2026-08-17 22:37:14.701047+00"']

--- a/testdata/specs/googlesql/syntax/query/cast.yaml
+++ b/testdata/specs/googlesql/syntax/query/cast.yaml
@@ -21,3 +21,13 @@ cases:
     expected:
       rows:
         - ['true']
+  - desc: cast timestamp column to string uses the canonical space/+00 form
+    sql: |-
+      SELECT CAST(ts AS STRING) AS r
+      FROM UNNEST([TIMESTAMP '2026-08-07 22:00:00+00', TIMESTAMP '2020-01-01 00:00:00.5+00', TIMESTAMP '2020-01-01 00:00:00.1234+00']) AS ts
+    expected:
+      unordered: true
+      rows:
+        - ['2026-08-07 22:00:00+00']
+        - ['2020-01-01 00:00:00.500+00']
+        - ['2020-01-01 00:00:00.123400+00']


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

Stacked on #54 (both now share one canonical TIMESTAMP-to-text form); the change on top of #54 is the last commit only.

## Problem

```sql
SELECT FORMAT('%t', t), FORMAT('%T', t) FROM (SELECT TIMESTAMP '2026-08-17 22:37:14.701047+00' AS t)
-- got:  2026-08-17 22:37:14+00         | TIMESTAMP "2026-08-17 22:37:14+00"
-- want: 2026-08-17 22:37:14.701047+00  | TIMESTAMP "2026-08-17 22:37:14.701047+00"   (BigQuery; same as CAST(t AS STRING))
```

## Fix

`%t` / `%T` render a TIMESTAMP through the same canonical form as the
STRING cast (UTC, `+00`, 0 / 3 / 6 fractional digits), now a method on
`TimestampValue` used by both paths.

## Tests

`testdata/specs/googlesql/functions/string/format.yaml`; the existing
canonical-form unit test in `internal/cast_test.go` now exercises the shared
method. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
