### PR TITLE
window: order MIN / MAX OVER (...) by value for non-numeric arguments

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -811,6 +811,25 @@ var customNativeWindowFuncMap = map[string]string{
 // nativeWindowFuncForName returns the SQLite native name for a
 // predecessor window function, or "" when no native equivalent
 // applies.
+// argumentIsNativeNumber reports whether the first argument reaches SQLite as
+// an INTEGER or REAL rather than an encoded value.
+func (n *AnalyticFunctionCallNode) argumentIsNativeNumber() bool {
+	args := m1(n.node.ResolvedFunctionCallBase.ArgumentList())
+	if len(args) == 0 {
+		return false
+	}
+	t, err := args[0].Type()
+	if err != nil || t == nil {
+		return false
+	}
+	switch m1(t.Kind()) {
+	case googlesql.TypeKindTypeInt32, googlesql.TypeKindTypeInt64, googlesql.TypeKindTypeUint32, googlesql.TypeKindTypeUint64,
+		googlesql.TypeKindTypeFloat, googlesql.TypeKindTypeDouble, googlesql.TypeKindTypeBool:
+		return true
+	}
+	return false
+}
+
 func nativeWindowFuncForName(name string) string {
 	if v, ok := nativeWindowFuncMap[name]; ok {
 		return v
@@ -843,6 +862,9 @@ func (n *AnalyticFunctionCallNode) FormatSQL(ctx context.Context) (string, error
 		if custom, ok := distinctAwareNativeWindowFuncs[rawName]; ok {
 			return n.formatNative(ctx, custom, orderColumns, true)
 		}
+	}
+	if (rawName == "min" || rawName == "max") && !n.argumentIsNativeNumber() {
+		return n.formatNative(ctx, "googlesqlite_window_"+rawName+"_ordered", orderColumns, false)
 	}
 	if native := nativeWindowFuncForName(rawName); native != "" && !n.requiresPredecessorEmulation() {
 		return n.formatNative(ctx, native, orderColumns, false)

--- a/internal/function_register.go
+++ b/internal/function_register.go
@@ -70,6 +70,8 @@ func RegisterFunctions(conn *sqlite3.Conn) error {
 		windowFuncMap["any_value"] = []*nameAndFunc{
 			{Name: "googlesqlite_window_any_value", Func: window.NewAnyValueWindowNative()},
 		}
+		windowFuncMap["min"] = append(windowFuncMap["min"], &nameAndFunc{Name: "googlesqlite_window_min_ordered", Func: window.NewMinOrderedWindowNative()})
+		windowFuncMap["max"] = append(windowFuncMap["max"], &nameAndFunc{Name: "googlesqlite_window_max_ordered", Func: window.NewMaxOrderedWindowNative()})
 		windowFuncMap["corr"] = []*nameAndFunc{
 			{Name: "googlesqlite_window_corr", Func: window.NewCorrWindowNative()},
 		}

--- a/internal/functions/window/native.go
+++ b/internal/functions/window/native.go
@@ -624,3 +624,67 @@ func (a *arrayConcatAggWindowNative) Done() (any, error) {
 	}
 	return value.EncodeValue(&value.ArrayValue{Values: flattened})
 }
+
+type extremumWindowNative struct {
+	values []value.Value
+	max    bool
+}
+
+func NewMinOrderedWindowNative() func() any {
+	return func() any { return &extremumWindowNative{} }
+}
+
+func NewMaxOrderedWindowNative() func() any {
+	return func() any { return &extremumWindowNative{max: true} }
+}
+
+func (a *extremumWindowNative) Step(stepArgs ...any) error {
+	values, err := value.ConvertArgs(stepArgs...)
+	if err != nil {
+		return err
+	}
+	values, _ = helper.ParseOptions(values...)
+	values, _ = parseWindowOptions(values...)
+	if len(values) == 0 {
+		return nil
+	}
+	a.values = append(a.values, values[0])
+	return nil
+}
+
+func (a *extremumWindowNative) Inverse(_ ...any) error {
+	if len(a.values) > 0 {
+		a.values = a.values[1:]
+	}
+	return nil
+}
+
+func (a *extremumWindowNative) Done() (any, error) {
+	var best value.Value
+	for _, v := range a.values {
+		if v == nil {
+			continue
+		}
+		if best == nil {
+			best = v
+			continue
+		}
+		var better bool
+		var err error
+		if a.max {
+			better, err = v.GT(best)
+		} else {
+			better, err = v.LT(best)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if better {
+			best = v
+		}
+	}
+	if best == nil {
+		return nil, nil
+	}
+	return value.EncodeValue(best)
+}

--- a/testdata/specs/googlesql/functions/aggregate/max.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/max.yaml
@@ -11,3 +11,11 @@ cases:
     expected:
       rows:
         - [null]
+  - desc: MAX as a window function orders DATETIME, TIME and STRING values correctly
+    sql: |
+      SELECT MAX(x) OVER () = DATETIME '2026-07-08 06:00:00', MAX(t) OVER () = TIME '08:00:00', MAX(s) OVER ()
+      FROM UNNEST([STRUCT(DATETIME '2026-07-08 06:00:00' AS x, TIME '08:00:00' AS t, 'b' AS s), (DATETIME '2026-07-01 06:00:00', TIME '01:00:00', 'c'), (DATETIME '2026-07-05 06:00:00', TIME '05:00:00', 'a')])
+      LIMIT 1
+    expected:
+      rows:
+        - [true, true, "c"]

--- a/testdata/specs/googlesql/functions/aggregate/min.yaml
+++ b/testdata/specs/googlesql/functions/aggregate/min.yaml
@@ -11,3 +11,14 @@ cases:
     expected:
       rows:
         - [null]
+  - desc: MIN as a window function orders DATETIME values correctly per partition and skips NULL
+    sql: |
+      SELECT p, MIN(x) OVER (PARTITION BY p) = DATETIME '2026-07-01 06:00:00', MIN(x) OVER (PARTITION BY p) = DATETIME '2026-07-05 06:00:00'
+      FROM UNNEST([STRUCT(1 AS p, DATETIME '2026-07-08 06:00:00' AS x), (1, DATETIME '2026-07-01 06:00:00'), (2, DATETIME '2026-07-05 06:00:00'), (2, CAST(NULL AS DATETIME))])
+      ORDER BY p
+    expected:
+      rows:
+        - [1, true, false]
+        - [1, true, false]
+        - [2, false, true]
+        - [2, false, true]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

`MIN` / `MAX` as window functions return an arbitrary row's value for
every argument type other than INT64 / FLOAT64 / BOOL (aggregate MIN / MAX
are fine):

```sql
WITH t AS (SELECT DATETIME '2026-07-08 06:00:00' x UNION ALL SELECT DATETIME '2026-07-01 06:00:00' UNION ALL SELECT DATETIME '2026-07-05 06:00:00')
SELECT MAX(x) OVER (), MIN(x) OVER () FROM t LIMIT 1
-- got:  2026-07-01T06:00:00 | 2026-07-05T06:00:00
-- want: 2026-07-08T06:00:00 | 2026-07-01T06:00:00   (BigQuery)
```
Same for TIME, STRING, NUMERIC, DATE, … — e.g. `x = MIN(x) OVER (PARTITION BY id)`
or `QUALIFY ts = MAX(ts) OVER (…)` silently pick the wrong rows.

## Cause

Analytic MIN / MAX are always emitted as SQLite's built-in window
`min`/`max`. Only INT64 / FLOAT64 / BOOL reach SQLite as native numbers;
every other type is stored in its encoded form, so SQLite compares the
encodings.

## Fix

Keep the built-ins for native numeric arguments; route every other
argument type to frame-driven natives (`Step`/`Inverse`/`Done`, same
shape as the existing `ANY_VALUE` native) that compare decoded values.
Verified against BigQuery with PARTITION BY, sliding ROWS frames and NULLs.

## Tests

`testdata/specs/googlesql/functions/aggregate/{min,max}.yaml` (DATETIME /
TIME / STRING, partitions, NULL). `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
