### PR TITLE
internal: emit the empty grouping set as a single group

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -1877,7 +1877,7 @@ func (n *AggregateScanNode) FormatSQL(ctx context.Context) (string, error) {
 		}
 		stmts := []string{}
 		for i := 0; i < len(columnPatterns); i++ {
-			var groupBy string
+			groupBy := "GROUP BY NULL"
 			if len(groupByColumnPatterns[i]) != 0 {
 				groupBy = fmt.Sprintf("GROUP BY %s", strings.Join(groupByColumnPatterns[i], ","))
 			}

--- a/testdata/specs/googlesql/syntax/query/grouping_sets.yaml
+++ b/testdata/specs/googlesql/syntax/query/grouping_sets.yaml
@@ -12,3 +12,15 @@ cases:
         - ['a', 3]
         - ['b', 3]
         - [null, 6]
+  - desc: the empty grouping set yields one grand-total row even without aggregate calls
+    sql: |-
+      SELECT a, o, GROUPING(a) * 2 + GROUPING(o) AS gid
+      FROM UNNEST([STRUCT('a1' AS a, 'o1' AS o), ('a2', 'o1')])
+      GROUP BY GROUPING SETS ((a, o), (o), ())
+      ORDER BY gid, a
+    expected:
+      rows:
+        - ['a1', 'o1', 0]
+        - ['a2', 'o1', 0]
+        - [null, 'o1', 2]
+        - [null, null, 3]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

The empty grouping set produces one "grand total" row per input row when
the select list has no aggregate call:

```sql
WITH e AS (SELECT 'a1' a, 'o1' o UNION ALL SELECT 'a2', 'o1')
SELECT a, o, GROUPING(a) * 2 + GROUPING(o) AS gid
FROM e GROUP BY GROUPING SETS ((a, o), (o), (a), ()) ORDER BY gid, a, o
-- got:  7 rows — (NULL, NULL, 3) twice
-- want: 6 rows — (NULL, NULL, 3) once   (BigQuery)
```

## Cause / fix

The formatter expands GROUPING SETS / ROLLUP / CUBE into one SELECT per
set; the arm for `()` was emitted without any GROUP BY, so without an
aggregate call nothing collapsed it. Group that arm by a constant so it is
always a single group (and, like BigQuery, yields no row on empty input).

## Tests

`testdata/specs/googlesql/syntax/query/grouping_sets.yaml`; the existing
ROLLUP / CUBE cases still pass. `go test ./...`, `go run ./cmd/specctl check --check` and `make lint` pass; each added case fails before and passes after.
