### PR TITLE
window: keep partition keys out of the native OVER ORDER BY

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -170,6 +170,7 @@ type analyticOrderBy struct {
 	column    string
 	isAsc     bool
 	nullOrder nullOrderMode
+	partition bool
 }
 
 type analyticOrderColumnNames struct {

--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -1007,21 +1007,24 @@ func (n *AnalyticFunctionCallNode) formatNative(ctx context.Context, sqliteName 
 	if cols := analyticPartitionColumnNamesFromContext(ctx); len(cols) > 0 {
 		clauses = append(clauses, "PARTITION BY "+strings.Join(cols, ","))
 	}
-	if len(orderColumns) > 0 {
-		var ob []string
-		for _, col := range orderColumns {
-			switch col.nullOrder {
-			case nullOrderFirst:
-				ob = append(ob, fmt.Sprintf("(%s IS NOT NULL)", col.column))
-			case nullOrderLast:
-				ob = append(ob, fmt.Sprintf("(%s IS NULL)", col.column))
-			}
-			suffix := " COLLATE googlesqlite_collate"
-			if !col.isAsc {
-				suffix += " DESC"
-			}
-			ob = append(ob, col.column+suffix)
+	var ob []string
+	for _, col := range orderColumns {
+		if col.partition {
+			continue
 		}
+		switch col.nullOrder {
+		case nullOrderFirst:
+			ob = append(ob, fmt.Sprintf("(%s IS NOT NULL)", col.column))
+		case nullOrderLast:
+			ob = append(ob, fmt.Sprintf("(%s IS NULL)", col.column))
+		}
+		suffix := " COLLATE googlesqlite_collate"
+		if !col.isAsc {
+			suffix += " DESC"
+		}
+		ob = append(ob, col.column+suffix)
+	}
+	if len(ob) > 0 {
 		clauses = append(clauses, "ORDER BY "+strings.Join(ob, ","))
 	}
 	if frameSQL, err := n.formatNativeFrame(ctx); err != nil {
@@ -2332,8 +2335,9 @@ func (n *AnalyticScanNode) FormatSQL(ctx context.Context) (string, error) {
 					colName,
 				)
 				order := &analyticOrderBy{
-					column: colName,
-					isAsc:  true,
+					column:    colName,
+					isAsc:     true,
+					partition: true,
 				}
 				orderColumnNames.values = append(orderColumnNames.values, order)
 				scanOrderBy = append(scanOrderBy, order)

--- a/testdata/specs/googlesql/syntax/query/window_clause.yaml
+++ b/testdata/specs/googlesql/syntax/query/window_clause.yaml
@@ -12,3 +12,14 @@ cases:
         - [1, 1]
         - [2, 3]
         - [3, 6]
+  - desc: RANGE offset frame with PARTITION BY
+    sql: |-
+      SELECT k, x, COUNT(*) OVER (PARTITION BY k ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS n
+      FROM UNNEST([STRUCT('a' AS k, 1 AS x), ('a', 2), ('a', 4), ('b', 1)])
+      ORDER BY k, x
+    expected:
+      rows:
+        - ['a', 1, 2]
+        - ['a', 2, 2]
+        - ['a', 4, 1]
+        - ['b', 1, 1]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

```sql
SELECT k, COUNT(*) OVER (PARTITION BY k ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS n
FROM UNNEST([STRUCT('a' AS k, 1 AS x), ('a', 2)])
-- got:  sqlite3: SQL logic error: RANGE with offset PRECEDING/FOLLOWING requires one ORDER BY expression
-- want: two rows with n = 2   (BigQuery)
```

The same frame without `PARTITION BY` works.

## Cause / fix

The partition columns are recorded in the shared order-column list (the
emulation path needs them there), and the native `OVER` clause emitted them
again as leading `ORDER BY` terms after `PARTITION BY`, giving SQLite two
ORDER BY expressions for a RANGE offset frame. Partition entries are now
marked and skipped when the native `ORDER BY` is built. Ordering by a
partition key inside its own partition is a no-op, so ROWS frames and
ranking functions are unchanged.

## Tests

`testdata/specs/googlesql/syntax/query/window_clause.yaml`. `go test ./...`,
`go run ./cmd/specctl check --check` and `make lint` pass; the added case fails
before and passes after.
