### PR TITLE
internal: keep BOOL arguments BOOL when they reach a function

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -137,6 +137,34 @@ func formatInput(input string) (string, error) {
 	return "", fmt.Errorf("unexpected input pattern: %s", input)
 }
 
+// SQLite stores a BOOL as 0 or 1, which a function would read as an INT64.
+func typeBoolArguments(node *ResolvedBaseFunctionCallNode, args []string) []string {
+	for i, a := range m1(node.ArgumentList()) {
+		if i < len(args) && isBoolExpr(a) {
+			args[i] = typedBoolSQL(args[i])
+		}
+	}
+	return args
+}
+
+func isBoolExpr(expr interface {
+	Type() (googlesql.Googlesql_TypeNode, error)
+}) bool {
+	t, _ := expr.Type()
+	if t == nil {
+		return false
+	}
+	k, err := t.Kind()
+	return err == nil && k == googlesql.TypeKindTypeBool
+}
+
+func typedBoolSQL(arg string) string {
+	return fmt.Sprintf(
+		"CASE (%s) WHEN 0 THEN %q WHEN 1 THEN %q END",
+		arg, value.EncodedBoolLayout(false), value.EncodedBoolLayout(true),
+	)
+}
+
 func getFuncNameAndArgs(ctx context.Context, node *ResolvedBaseFunctionCallNode, isWindowFunc bool) (string, []string, error) {
 	args := []string{}
 	for _, a := range m1(node.ArgumentList()) {
@@ -387,6 +415,9 @@ func (n *FunctionCallNode) FormatSQL(ctx context.Context) (string, error) {
 	funcMap := funcMapFromContext(ctx)
 	if spec, exists := funcMap[funcName]; exists {
 		return spec.CallSQL(ctx, n.node.ResolvedFunctionCallBase, args)
+	}
+	if strings.HasPrefix(funcName, "googlesqlite_") {
+		args = typeBoolArguments(n.node.ResolvedFunctionCallBase, args)
 	}
 	return fmt.Sprintf(
 		"%s(%s)",
@@ -723,6 +754,9 @@ func (n *AggregateFunctionCallNode) FormatSQL(ctx context.Context) (string, erro
 	case googlesql.ResolvedNonScalarFunctionCallBaseEnums_NullHandlingModifierIgnoreNulls:
 		opts = append(opts, "googlesqlite_ignore_nulls()")
 	case googlesql.ResolvedNonScalarFunctionCallBaseEnums_NullHandlingModifierRespectNulls:
+	}
+	if strings.HasPrefix(funcName, "googlesqlite_") {
+		args = typeBoolArguments(n.node.ResolvedFunctionCallBase, args)
 	}
 	args = append(args, opts...)
 	return fmt.Sprintf(
@@ -1166,6 +1200,9 @@ func (n *MakeStructNode) FormatSQL(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		if isBoolExpr(fields[i]) {
+			field = typedBoolSQL(field)
+		}
 		args = append(args, field)
 	}
 	return fmt.Sprintf("googlesqlite_make_struct(%s)", strings.Join(args, ",")), nil
@@ -1527,8 +1564,11 @@ func (n *SubqueryExprNode) FormatSQL(ctx context.Context) (string, error) {
 		if len(subCols) == 0 {
 			return "", fmt.Errorf("failed to find computed column names for array subquery")
 		}
-		colName := uniqueColumnName(ctx, subCols[0])
-		return fmt.Sprintf("(SELECT googlesqlite_array(`%s`) FROM (%s))", colName, sql), nil
+		elem := fmt.Sprintf("`%s`", uniqueColumnName(ctx, subCols[0]))
+		if isBoolExpr(subCols[0]) {
+			elem = typedBoolSQL(elem)
+		}
+		return fmt.Sprintf("(SELECT googlesqlite_array(%s) FROM (%s))", elem, sql), nil
 	case googlesql.ResolvedSubqueryExprEnums_SubqueryTypeExists:
 		return fmt.Sprintf("EXISTS (%s)", sql), nil
 	case googlesql.ResolvedSubqueryExprEnums_SubqueryTypeIn:

--- a/internal/functions/math/math_test.go
+++ b/internal/functions/math/math_test.go
@@ -563,14 +563,14 @@ func TestRoundErrorPath(t *testing.T) {
 
 // TestBindGreatestErrorPath drives a value type that errors on GT.
 func TestBindGreatestErrorPath(t *testing.T) {
-	if _, err := BindGreatest(value.BoolValue(true), value.BoolValue(false)); err == nil {
-		t.Errorf("BindGreatest: GT error not propagated for BOOL")
+	if _, err := BindGreatest(newBad(), value.IntValue(1)); err == nil {
+		t.Errorf("BindGreatest: GT error not propagated")
 	}
 }
 
 func TestBindLeastErrorPath(t *testing.T) {
-	if _, err := BindLeast(value.BoolValue(true), value.BoolValue(false)); err == nil {
-		t.Errorf("BindLeast: LT error not propagated for BOOL")
+	if _, err := BindLeast(newBad(), value.IntValue(1)); err == nil {
+		t.Errorf("BindLeast: LT error not propagated")
 	}
 }
 

--- a/internal/value/decoder.go
+++ b/internal/value/decoder.go
@@ -80,6 +80,12 @@ func DecodeValue(v any) (Value, error) {
 	if !ok {
 		return nil, fmt.Errorf("unexpected value type: %T", v)
 	}
+	switch s {
+	case encodedBoolLayouts[0]:
+		return BoolValue(false), nil
+	case encodedBoolLayouts[1]:
+		return BoolValue(true), nil
+	}
 	// Try the canonical base64-of-JSON envelope first. If either step
 	// fails the input is most likely a raw SQL string literal (e.g.
 	// `'int32'`, `'date'`, `'bytes'`) that the formatter inlined
@@ -101,6 +107,12 @@ func DecodeValue(v any) (Value, error) {
 
 func decodeFromValueLayout(layout *ValueLayout) (Value, error) {
 	switch layout.Header {
+	case BoolValueType:
+		b, err := strconv.ParseBool(layout.Body)
+		if err != nil {
+			return nil, err
+		}
+		return BoolValue(b), nil
 	case StringValueType:
 		return StringValue(layout.Body), nil
 	case BytesValueType:

--- a/internal/value/encoder.go
+++ b/internal/value/encoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -133,6 +134,11 @@ func ValueLayoutFromValue(v Value) (*ValueLayout, error) {
 
 func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 	switch vv := v.(type) {
+	case BoolValue:
+		return &ValueLayout{
+			Header: BoolValueType,
+			Body:   strconv.FormatBool(bool(vv)),
+		}, nil
 	case StringValue:
 		return &ValueLayout{
 			Header: StringValueType,
@@ -295,4 +301,22 @@ func valueLayoutFromValue(v Value) (*ValueLayout, error) {
 		}, nil
 	}
 	return nil, fmt.Errorf("unexpected value type for layout: %T", v)
+}
+
+var encodedBoolLayouts = [2]string{encodeBoolLayout(false), encodeBoolLayout(true)}
+
+func encodeBoolLayout(b bool) string {
+	out, err := json.Marshal(&ValueLayout{Header: BoolValueType, Body: strconv.FormatBool(b)})
+	if err != nil {
+		panic(err)
+	}
+	return base64.StdEncoding.EncodeToString(out)
+}
+
+// EncodedBoolLayout is the form of a BOOL that keeps its type as a function argument.
+func EncodedBoolLayout(b bool) string {
+	if b {
+		return encodedBoolLayouts[1]
+	}
+	return encodedBoolLayouts[0]
 }

--- a/internal/value/value_bool.go
+++ b/internal/value/value_bool.go
@@ -33,19 +33,35 @@ func (bv BoolValue) EQ(v Value) (bool, error) {
 }
 
 func (bv BoolValue) GT(v Value) (bool, error) {
-	return false, fmt.Errorf("gt operation is unsupported for bool %v", bv)
+	v2, err := v.ToBool()
+	if err != nil {
+		return false, fmt.Errorf("failed to convert %v to bool", v)
+	}
+	return bool(bv) && !v2, nil
 }
 
 func (bv BoolValue) GTE(v Value) (bool, error) {
-	return false, fmt.Errorf("gte operation is unsupported for bool %v", bv)
+	v2, err := v.ToBool()
+	if err != nil {
+		return false, fmt.Errorf("failed to convert %v to bool", v)
+	}
+	return bool(bv) || !v2, nil
 }
 
 func (bv BoolValue) LT(v Value) (bool, error) {
-	return false, fmt.Errorf("lt operation is unsupported for bool %v", bv)
+	v2, err := v.ToBool()
+	if err != nil {
+		return false, fmt.Errorf("failed to convert %v to bool", v)
+	}
+	return !bool(bv) && v2, nil
 }
 
 func (bv BoolValue) LTE(v Value) (bool, error) {
-	return false, fmt.Errorf("lte operation is unsupported for bool %v", bv)
+	v2, err := v.ToBool()
+	if err != nil {
+		return false, fmt.Errorf("failed to convert %v to bool", v)
+	}
+	return !bool(bv) || v2, nil
 }
 
 func (bv BoolValue) ToInt64() (int64, error) {

--- a/internal/value/value_bool_test.go
+++ b/internal/value/value_bool_test.go
@@ -45,19 +45,28 @@ func TestBoolValue(t *testing.T) {
 		}
 	})
 
-	t.Run("GT/GTE/LT/LTE unsupported", func(t *testing.T) {
-		bv := value.BoolValue(true)
-		if _, err := bv.GT(bv); err == nil {
-			t.Fatal("GT should be unsupported")
+	t.Run("FALSE orders before TRUE", func(t *testing.T) {
+		f, tr := value.BoolValue(false), value.BoolValue(true)
+		for _, c := range []struct {
+			name string
+			op   func(value.Value) (bool, error)
+			rhs  value.Value
+			want bool
+		}{
+			{"false < true", f.LT, tr, true},
+			{"true < false", tr.LT, f, false},
+			{"true <= true", tr.LTE, tr, true},
+			{"true > false", tr.GT, f, true},
+			{"false > false", f.GT, f, false},
+			{"false >= true", f.GTE, tr, false},
+		} {
+			got, err := c.op(c.rhs)
+			if err != nil || got != c.want {
+				t.Errorf("%s = %v, %v; want %v", c.name, got, err, c.want)
+			}
 		}
-		if _, err := bv.GTE(bv); err == nil {
-			t.Fatal("GTE should be unsupported")
-		}
-		if _, err := bv.LT(bv); err == nil {
-			t.Fatal("LT should be unsupported")
-		}
-		if _, err := bv.LTE(bv); err == nil {
-			t.Fatal("LTE should be unsupported")
+		if _, err := tr.GT(&value.ArrayValue{}); err == nil {
+			t.Error("GT with a non-bool operand should fail")
 		}
 	})
 

--- a/testdata/specs/googlesql/functions/json/to_json_string.yaml
+++ b/testdata/specs/googlesql/functions/json/to_json_string.yaml
@@ -44,3 +44,16 @@ cases:
     expected:
       rows:
         - ['[]']
+  - desc: BOOL from a column or an expression keeps its type
+    sql: |-
+      WITH t AS (SELECT FALSE AS b)
+      SELECT TO_JSON_STRING(b), TO_JSON_STRING(STRUCT(b, FALSE AS lit)), TO_JSON_STRING([b, 1 > 0]), TO_JSON_STRING(CAST(NULL AS BOOL))
+      FROM t
+    expected:
+      rows:
+        - ['false', '{"b":false,"lit":false}', '[false,true]', 'null']
+  - desc: ARRAY_AGG of BOOL keeps its type with and without ORDER BY
+    sql: SELECT TO_JSON_STRING(ARRAY_AGG(x)), TO_JSON_STRING(ARRAY_AGG(x ORDER BY x)) FROM UNNEST([TRUE, FALSE]) AS x
+    expected:
+      rows:
+        - ['[true,false]', '[false,true]']

--- a/testdata/specs/googlesql/functions/math/greatest.yaml
+++ b/testdata/specs/googlesql/functions/math/greatest.yaml
@@ -6,3 +6,8 @@ cases:
     expected:
       rows:
         - [5]
+  - desc: BOOL arguments order FALSE before TRUE
+    sql: SELECT GREATEST(FALSE, TRUE), LEAST(TRUE, FALSE), FALSE < TRUE
+    expected:
+      rows:
+        - [true, false, true]


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

```sql
WITH t AS (SELECT FALSE AS b) SELECT TO_JSON_STRING(STRUCT(b, FALSE AS lit)) FROM t
-- got:  {"b":0,"lit":0}
-- want: {"b":false,"lit":false}   (BigQuery)

SELECT TO_JSON_STRING(FALSE)
-- got:  0
-- want: false
```

`ARRAY_AGG(b)` likewise built an array of integers. Only literals folded by
the analyzer kept their type.

## Cause / fix

SQLite stores a BOOL as the integer 0 or 1, so a Go function receiving a BOOL
column or expression saw an INT64. Each BOOL-typed argument of a Go function,
each BOOL field of a struct constructor and a BOOL element of an ARRAY
subquery is now passed as
`CASE (x) WHEN 0 THEN <false> WHEN 1 THEN <true> END`, where the two branches
are the encoded BOOL layout. The expression is evaluated once and NULL stays
NULL. The decoder compares an argument against the two encoded strings before
any other decoding, so a BOOL argument costs one string comparison. Calls
that SQLite evaluates itself (the CASE forms of IF / IFNULL, native window
functions) keep the integer.

A function that now receives a `BoolValue` where it used to get an `IntValue`
may compare it, so `BoolValue` implements GT / GTE / LT / LTE with FALSE
ordered before TRUE, as in BigQuery (`GREATEST(FALSE, TRUE)` is `TRUE`).

## Tests

`internal/value/value_bool_test.go`, `internal/functions/math/math_test.go`,
`testdata/specs/googlesql/functions/json/to_json_string.yaml`,
`testdata/specs/googlesql/functions/math/greatest.yaml`. `go test ./...`,
`go run ./cmd/specctl check --check` and `make lint` pass; each added case
fails before and passes after.
