### PR TITLE
internal: build path sub-catalogs without the builtin function set

### DIFF
--- a/internal/catalog.go
+++ b/internal/catalog.go
@@ -1674,8 +1674,8 @@ func (c *Catalog) getOrCreateSubCatalog(parent *googlesql.SimpleCatalog, name st
 	if existing, ok := subs[name]; ok {
 		return existing
 	}
-	sub := newSimpleCatalog(name)
-	if sub == nil {
+	sub, err := googlesql.NewSimpleCatalog(name, tf())
+	if err != nil || sub == nil {
 		return nil
 	}
 	_ = parent.AddCatalog(sub)


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

A process that keeps creating tables under new dataset names retains memory
for every dataset it has ever seen and never gives it back. Measured on
goccy/bigquery-emulator, which stores each query result in a dataset named
after the job id, so every `jobs.insert` creates one:

| query | 0.8.1 | after 40 | after 80 | after 200 |
|---|---|---|---|---|
| `SELECT x, COUNT(*) OVER () FROM UNNEST(GENERATE_ARRAY(1, 200)) AS x` | 99 MB | 881 MB | 1813 MB | |
| same, with this change | 105 MB | 349 MB | 301 MB | 342 MB |

A 30 KB CTE-heavy query retained about 90 MB per run (1465 MB after 15);
with this change (and the other open PRs applied so the query runs) it settles
around 365 MB.

## Cause / fix

Every sub-catalog created for a table path segment (a project or dataset
name) was built with `newSimpleCatalog`, which registers the whole GoogleSQL
builtin function set plus the BigQuery and Spanner extension families into
it. That registration lives in the wasm linear memory, which only grows.
Heap profile of the emulator process: 90% of `inuse_space` is `MemoryGrow`
under `Catalog.getOrCreateSubCatalog → newSimpleCatalog`. The analyzer
resolves functions through the root catalog; a path sub-catalog only has to
hold the tables, TVFs and INFORMATION_SCHEMA views registered under that
segment, so it is now a bare `SimpleCatalog`.

The package test suite also runs about 17% faster (22.5 s → 18.8 s here),
since tests that create tables no longer register thousands of signatures
per dataset.

## Tests

No new test: the change is not observable through query results. `go test
./...`, `go run ./cmd/specctl check --check` and `make lint` pass. One full
parallel run showed a wasm out-of-bounds trap in `TestW_TVF_Call`; seven
further runs on this branch and on main were clean, so I believe it is
unrelated, but flagging it.
