### PR TITLE
internal: name set operation output columns positionally in every branch

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -2130,11 +2130,15 @@ func (n *SetOperationScanNode) FormatSQL(ctx context.Context) (string, error) {
 	default:
 		opType = "UNKNOWN"
 	}
+	var resultColumns []string
+	for _, col := range m1(n.node.ColumnList()) {
+		resultColumns = append(resultColumns, fmt.Sprintf("`%s`", uniqueColumnName(ctx, col)))
+	}
 	var queries []string
 	for _, item := range m1(n.node.InputItemList()) {
 		var outputColumns []string
-		for _, outputColumn := range m1(item.OutputColumnList()) {
-			outputColumns = append(outputColumns, fmt.Sprintf("`%s`", uniqueColumnName(ctx, outputColumn)))
+		for idx, outputColumn := range m1(item.OutputColumnList()) {
+			outputColumns = append(outputColumns, fmt.Sprintf("`%s` AS %s", uniqueColumnName(ctx, outputColumn), resultColumns[idx]))
 		}
 		query, err := newNode(item).FormatSQL(ctx)
 		if err != nil {
@@ -2154,22 +2158,9 @@ func (n *SetOperationScanNode) FormatSQL(ctx context.Context) (string, error) {
 			),
 		)
 	}
-	columnMaps := []string{}
-	if inputItems := m1(n.node.InputItemList()); len(inputItems) != 0 {
-		for idx, col := range m1(inputItems[0].OutputColumnList()) {
-			columnMaps = append(
-				columnMaps,
-				fmt.Sprintf(
-					"`%s` AS `%s`",
-					uniqueColumnName(ctx, col),
-					uniqueColumnName(ctx, m1(n.node.ColumnList())[idx]),
-				),
-			)
-		}
-	}
 	return fmt.Sprintf(
 		"SELECT %s FROM (%s)",
-		strings.Join(columnMaps, ","),
+		strings.Join(resultColumns, ","),
 		strings.Join(queries, fmt.Sprintf(" %s ", opType)),
 	), nil
 }

--- a/testdata/specs/googlesql/syntax/query/union.yaml
+++ b/testdata/specs/googlesql/syntax/query/union.yaml
@@ -16,3 +16,13 @@ cases:
         - [1]
         - [2]
         - [3]
+  - desc: a branch that projects one column twice does not capture later branches' columns
+    sql: |-
+      SELECT x, x AS y FROM (SELECT 's1' AS x)
+      UNION ALL SELECT p AS x, q AS y FROM (SELECT 'r' AS p, 'k' AS q)
+      UNION ALL SELECT 'u', 'v'
+    expected:
+      rows:
+        - ['s1', 's1']
+        - ['r', 'k']
+        - ['u', 'v']


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

```sql
SELECT x, x AS y FROM (SELECT 's1' AS x)
UNION ALL SELECT p AS x, q AS y FROM (SELECT 'r' AS p, 'k' AS q)
-- got:  ('s1','s1'), ('r','r')
-- want: ('s1','s1'), ('r','k')   (BigQuery)
```

Every branch after the first returns its first column twice whenever the
first branch projects one column under two names.

## Cause / fix

The compound select's outer projection read the result columns by the
first branch's column names. With `x, x AS y` both result columns carried
the same name, so every reference resolved to the first one and later
branches' second column was replaced by their first.

Each branch's output columns are now aliased positionally to the set
operation's own output column names, and the outer projection selects
those names directly, so no branch column name is reused. Applies to all
set operation kinds.

## Tests

`testdata/specs/googlesql/syntax/query/union.yaml`. `go test ./...`,
`go run ./cmd/specctl check --check` and `make lint` pass; the added case
fails before and passes after.
