### PR TITLE
internal: emit MATERIALIZED for every non-recursive CTE

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -49,8 +49,8 @@ func ChangedCatalogFromResult(result sql.Result) (*ChangedCatalog, error) {
 	return googlesqliteResult.ChangedCatalog(), nil
 }
 
-// SetMaterializeCTE controls whether CTEs referenced more than once
-// are emitted with the SQLite MATERIALIZED hint.
+// SetMaterializeCTE controls whether CTEs are emitted with the SQLite
+// MATERIALIZED hint.
 func (c *Conn) SetMaterializeCTE(enabled bool) { c.materializeCTE = enabled }
 
 // MaterializeCTE reports the current materialize-multi-ref-CTE flag.

--- a/internal/conn.go
+++ b/internal/conn.go
@@ -121,9 +121,8 @@ func (c *Conn) ScriptVariable(name string) (string, bool) {
 	return v, ok
 }
 
-// MaterializeCTE reports the materialize-multi-ref-CTE flag for this
-// connection. The formatter consults this through context to decide
-// whether to emit the SQLite `MATERIALIZED` hint.
+// MaterializeCTE reports whether the formatter emits the SQLite
+// `MATERIALIZED` hint on CTEs.
 func (c *Conn) MaterializeCTE() bool {
 	return c.materializeCTE
 }

--- a/internal/context.go
+++ b/internal/context.go
@@ -16,7 +16,6 @@ type (
 	tvfMapKey                       struct{}
 	systemVarsKey                   struct{}
 	connKey                         struct{}
-	cteRefCountsKey                 struct{}
 	analyticOrderColumnNamesKey     struct{}
 	analyticPartitionColumnNamesKey struct{}
 	analyticInputScanKey            struct{}
@@ -135,23 +134,6 @@ func connFromContext(ctx context.Context) *Conn {
 		return nil
 	}
 	return value.(*Conn)
-}
-
-// withCteRefCounts carries a CTE-name → reference-count map through
-// the formatter, populated by WithScanNode just before it formats
-// the WITH entries. WithEntryNode reads it to decide whether to
-// emit the SQLite `MATERIALIZED` hint for entries that are
-// referenced more than once.
-func withCteRefCounts(ctx context.Context, m map[string]int) context.Context {
-	return context.WithValue(ctx, cteRefCountsKey{}, m)
-}
-
-func cteRefCounts(ctx context.Context) map[string]int {
-	value := ctx.Value(cteRefCountsKey{})
-	if value == nil {
-		return nil
-	}
-	return value.(map[string]int)
 }
 
 // nullOrderMode represents the OVER (ORDER BY ... NULLS FIRST/LAST)

--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -2719,34 +2719,15 @@ func (n *WithScanNode) FormatSQL(ctx context.Context) (string, error) {
 			break
 		}
 	}
-	// Count CTE references in the WITH body and across WithEntry
-	// subqueries (a later CTE may reference an earlier one). Pass
-	// the counts down so WithEntryNode.FormatSQL can decide whether
-	// to emit `MATERIALIZED`.
-	refCounts := map[string]int{}
-	if conn := connFromContext(ctx); conn == nil || conn.MaterializeCTE() {
-		query, _ := n.node.Query()
-		if query != nil {
-			collectCteRefCounts(query, refCounts)
-		}
-		for _, entry := range m1(n.node.WithEntryList()) {
-			sub, _ := entry.WithSubquery()
-			if sub == nil {
-				continue
-			}
-			collectCteRefCounts(sub, refCounts)
-		}
-	}
-	subCtx := withCteRefCounts(ctx, refCounts)
 	queries := []string{}
 	for _, entry := range m1(n.node.WithEntryList()) {
-		sql, err := newNode(entry).FormatSQL(subCtx)
+		sql, err := newNode(entry).FormatSQL(ctx)
 		if err != nil {
 			return "", err
 		}
 		queries = append(queries, sql)
 	}
-	query, err := newNode(m1(n.node.Query())).FormatSQL(subCtx)
+	query, err := newNode(m1(n.node.Query())).FormatSQL(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -2756,26 +2737,6 @@ func (n *WithScanNode) FormatSQL(ctx context.Context) (string, error) {
 		strings.Join(queries, ", "),
 		query,
 	), nil
-}
-
-// collectCteRefCounts walks a resolved-scan subtree and increments
-// counts[name] for every ResolvedWithRefScan it encounters. Used by
-// WithScanNode to decide whether each CTE body should be emitted as
-// `MATERIALIZED`.
-func collectCteRefCounts(node googlesql.ResolvedNode, counts map[string]int) {
-	if node == nil {
-		return
-	}
-	if kind, _ := node.NodeKind(); kind == googlesql.ResolvedNodeKindResolvedWithRefScan {
-		if ref, ok := node.(*googlesql.ResolvedWithRefScan); ok {
-			name, _ := ref.WithQueryName()
-			counts[name]++
-		}
-	}
-	children, _ := node.GetChildNodes()
-	for _, c := range children {
-		collectCteRefCounts(c, counts)
-	}
 }
 
 func (n *WithEntryNode) FormatSQL(ctx context.Context) (string, error) {
@@ -2797,7 +2758,7 @@ func (n *WithEntryNode) FormatSQL(ctx context.Context) (string, error) {
 	}
 	tableToColumnList := tableNameToColumnListMap(ctx)
 	tableToColumnList[queryName] = m1(sub.MutableColumnList())
-	hint := cteMaterializeHint(ctx, queryName, subKind)
+	hint := cteMaterializeHint(ctx, subKind)
 	if subKind == googlesql.ResolvedNodeKindResolvedRecursiveScan {
 		// SQLite needs an explicit column list on the recursive CTE
 		// so both UNION branches map their projected columns by
@@ -2815,21 +2776,17 @@ func (n *WithEntryNode) FormatSQL(ctx context.Context) (string, error) {
 	return fmt.Sprintf("`%s` AS%s ( %s )", queryName, hint, subquery), nil
 }
 
-// cteMaterializeHint returns either " MATERIALIZED" (with a leading
-// space) or "" depending on whether SQLite should be told to push
-// this CTE into a transient temp table instead of inlining its body
-// once per reference. Recursive CTEs are skipped — SQLite always
-// materialises the recursion accumulator anyway, and the hint
-// interacts oddly with the `WITH RECURSIVE` keyword.
-func cteMaterializeHint(ctx context.Context, queryName string, subKind googlesql.ResolvedNodeKind) string {
+// SQLite inlines a CTE referenced once into its consumer; for a large
+// compound body that copies the consumer once per arm, and preparing the
+// statement can exhaust the connection's memory.
+func cteMaterializeHint(ctx context.Context, subKind googlesql.ResolvedNodeKind) string {
 	if subKind == googlesql.ResolvedNodeKindResolvedRecursiveScan {
 		return ""
 	}
-	counts := cteRefCounts(ctx)
-	if counts[queryName] >= 2 {
-		return " MATERIALIZED"
+	if conn := connFromContext(ctx); conn != nil && !conn.MaterializeCTE() {
+		return ""
 	}
-	return ""
+	return " MATERIALIZED"
 }
 
 func (n *AnalyticFunctionGroupNode) FormatSQL(ctx context.Context) (string, error) {


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

A statement whose consumer nests a few GROUP BY subqueries over a CTE that
is a UNION ALL of literal rows fails to prepare once the CTE has enough
arms:

```
googlesqlite: panic sqlite3: out of memory
```

On a 124 KB statement with a 65-arm CTE, preparing needed 250-275 MB of the
connection's wasm memory (about 3.9 MB per arm) against the 256 MB default
cap, so roughly half of fresh connections failed on identical bytes.

## Cause / fix

The `MATERIALIZED` hint was only emitted for a CTE referenced at least
twice. SQLite inlines a CTE referenced once into its consumer, and for a
compound body the flattener copies the consuming statement once per arm.

Emit the hint for every non-recursive CTE when the connection's
`MaterializeCTE` flag is set (the default), and drop the reference counting
that fed the old rule. The hint is planner-only, so results are unchanged.
Measured on the statement above, fresh process each run:

| | peak RSS | time |
|---|---|---|
| before | 460-510 MB | 2.2 s |
| after | 237-282 MB | 0.9 s |

## Tests

Existing multi-ref, single-ref, recursive and toggle tests
(`TestW_CteMaterializeMultiRef`, `TestSetMaterializeCTEAndAutoIndex`) cover
the paths. `go test ./...`, `go run ./cmd/specctl check --check` and
`make lint` pass.
