### PR TITLE
driver: open each SQLite connection with a 1 GiB memory cap

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -67,6 +67,10 @@ var (
 // internal.RegisterFunctions on each new connection.
 const internalDriverName = "googlesqlite_sqlite3"
 
+// A statement is prepared inside one connection's wasm memory, which the
+// Go runtime's own limits do not see; ncruces caps it at 256 MB by default.
+const sqliteConnectionMemoryLimit = 1 << 30
+
 func init() {
 	sql.Register("googlesqlite", &Driver{})
 	sql.Register(internalDriverName, &internalSQLiteDriver{})
@@ -78,7 +82,11 @@ type internalSQLiteDriver struct{}
 
 func (internalSQLiteDriver) Open(name string) (driver.Conn, error) {
 	path, _ := dsnParts(name)
-	conn, err := (&sqlitedriver.SQLite{}).Open(path)
+	connector, err := (&sqlitedriver.SQLite{}).OpenConnector(path)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := connector.Connect(sqlite3.WithMaxMemory(context.Background(), sqliteConnectionMemoryLimit))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
> **Note:** This PR was generated by AI (with human review).

## Problem

A statement whose prepare needs more than 256 MB of a connection's wasm
memory fails with `sqlite3: out of memory` while the process has memory to
spare. ncruces/go-sqlite3 caps each connection at 256 MB unless the opening
context carries a larger limit, and that memory is mapped outside the Go
heap, so `GOMEMLIMIT` and `GOGC` do not apply to it.

## Fix

Open the inner connection through the driver's connector with a 1 GiB
`sqlite3.WithMaxMemory` limit. The limit is a reservation, not an
allocation: pages are only committed as SQLite touches them, so a
connection that never needs the room costs nothing extra.

## Tests

No behaviour change is observable through query results. `go test ./...`,
`go run ./cmd/specctl check --check` and `make lint` pass.
